### PR TITLE
Improve view layouts

### DIFF
--- a/Ballog/Views/ContentView.swift
+++ b/Ballog/Views/ContentView.swift
@@ -9,6 +9,12 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         TabView {
+            MainHomeView()
+                .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("홈")
+                }
+
             PersonalTrainingView()
                 .tabItem {
                     Image(systemName: "figure.walk")
@@ -21,13 +27,17 @@ struct ContentView: View {
                     Text("팀")
                 }
 
-            MainHomeView()
+            FeedView()
                 .tabItem {
-                    Image(systemName: "house.fill")
-                    Text("홈")
+                    Image(systemName: "square.stack")
+                    Text("피드")
                 }
 
-
+            SettingsView()
+                .tabItem {
+                    Image(systemName: "gearshape")
+                    Text("설정")
+                }
         }
     }
 }

--- a/Ballog/Views/FeedView.swift
+++ b/Ballog/Views/FeedView.swift
@@ -6,3 +6,24 @@
 //
 
 import SwiftUI
+
+struct FeedView: View {
+    let posts = [
+        "오늘 개인 훈련을 마쳤어요!",
+        "팀 훈련에서 새로운 전술을 배웠습니다.",
+        "주말 경기 일정이 확정됐어요."
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List(posts, id: \.self) { post in
+                Text(post)
+            }
+            .navigationTitle("피드")
+        }
+    }
+}
+
+#Preview {
+    FeedView()
+}

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct MainHomeView: View {
     var body: some View {
-        VStack(spacing: 0) {
+        NavigationStack {
+            VStack(spacing: 0) {
             // 상단 바
             HStack {
                 Text("볼터치")
@@ -62,10 +63,9 @@ struct MainHomeView: View {
             }
             .padding(.top, 16)
 
-            Spacer()
-            
-            // 탭바
-            TabBarView()
+                Spacer()
+            }
+            .navigationTitle("홈")
         }
     }
 }

--- a/Ballog/Views/PersonalTrainingView.swift
+++ b/Ballog/Views/PersonalTrainingView.swift
@@ -9,84 +9,86 @@ import SwiftUI
 
 struct PersonalTrainingView: View {
     var body: some View {
-        VStack(spacing: 16) {
-            // 상단 달력 헤더
-            HStack {
-                Text("2025년 7월")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                Spacer()
-                Button(action: {
-                    // 달력 전체 페이지 이동
-                }) {
-                    Text("달력 보기")
-                        .foregroundColor(.blue)
+        NavigationStack {
+            VStack(spacing: 16) {
+                // 상단 달력 헤더
+                HStack {
+                    Text("2025년 7월")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Spacer()
+                    Button(action: {
+                        // 달력 전체 페이지 이동
+                    }) {
+                        Text("달력 보기")
+                            .foregroundColor(.blue)
+                    }
                 }
-            }
-            .padding(.horizontal)
+                .padding(.horizontal)
 
             // 훈련일지 작성 버튼
-            Button(action: {
-                // 훈련일지 작성 페이지 이동
-            }) {
-                Text("📝 훈련일지 작성하기")
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(Color.yellow.opacity(0.2))
-                    .cornerRadius(10)
-            }
-            .padding(.horizontal)
+                Button(action: {
+                    // 훈련일지 작성 페이지 이동
+                }) {
+                    Text("📝 훈련일지 작성하기")
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.yellow.opacity(0.2))
+                        .cornerRadius(10)
+                }
+                .padding(.horizontal)
 
             // 최근 훈련일지 요약 리스트
-            VStack(alignment: .leading, spacing: 8) {
-                Text("📋 최근 훈련 일지")
-                    .font(.headline)
-                ForEach(0..<5) { index in
-                    HStack {
-                        Text("7월 \(20 - index)일 • 개인훈련")
-                        Spacer()
-                        Text("👍 훈련완료")
-                            .font(.caption)
-                            .foregroundColor(.green)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("📋 최근 훈련 일지")
+                        .font(.headline)
+                    ForEach(0..<5) { index in
+                        HStack {
+                            Text("7월 \(20 - index)일 • 개인훈련")
+                            Spacer()
+                            Text("👍 훈련완료")
+                                .font(.caption)
+                                .foregroundColor(.green)
+                        }
+                        .padding(.vertical, 4)
+                        Divider()
                     }
-                    .padding(.vertical, 4)
-                    Divider()
+                    Button("전체 보기 →") {
+                        // 전체 훈련일지 리스트 페이지 이동
+                    }
+                    .font(.caption)
+                    .foregroundColor(.blue)
+                    .padding(.top, 4)
                 }
-                Button("전체 보기 →") {
-                    // 전체 훈련일지 리스트 페이지 이동
-                }
-                .font(.caption)
-                .foregroundColor(.blue)
-                .padding(.top, 4)
-            }
-            .padding(.horizontal)
+                .padding(.horizontal)
 
             // 훈련 통계 요약
-            VStack(alignment: .leading, spacing: 8) {
-                Text("📊 훈련 통계 요약")
-                    .font(.headline)
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text("총 횟수: 12회")
-                        Text("총 시간: 10시간")
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("📊 훈련 통계 요약")
+                        .font(.headline)
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text("총 횟수: 12회")
+                            Text("총 시간: 10시간")
+                        }
+                        Spacer()
+                        VStack(alignment: .leading) {
+                            Text("기술별: 삼자패스 2h")
+                            Text("유형별: 개인 6 / 팀 4 / 경기 2")
+                        }
                     }
-                    Spacer()
-                    VStack(alignment: .leading) {
-                        Text("기술별: 삼자패스 2h")
-                        Text("유형별: 개인 6 / 팀 4 / 경기 2")
+                    Button("상세 통계 보기 →") {
+                        // 통계 페이지 이동
                     }
+                    .font(.caption)
+                    .foregroundColor(.blue)
                 }
-                Button("상세 통계 보기 →") {
-                    // 통계 페이지 이동
-                }
-                .font(.caption)
-                .foregroundColor(.blue)
-            }
-            .padding(.horizontal)
+                .padding(.horizontal)
 
-            Spacer()
+                Spacer()
+            }
+            .navigationTitle("개인 훈련")
         }
-        .navigationTitle("개인 훈련")
     }
 }
 

--- a/Ballog/Views/SettingsView.swift
+++ b/Ballog/Views/SettingsView.swift
@@ -6,4 +6,25 @@
 //
 
 import SwiftUI
-ㄴ
+
+struct SettingsView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section(header: Text("계정")) {
+                    Text("프로필")
+                    Text("로그아웃")
+                }
+
+                Section(header: Text("정보")) {
+                    Text("버전 1.0")
+                }
+            }
+            .navigationTitle("설정")
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/Ballog/Views/TeamManagementView.swift
+++ b/Ballog/Views/TeamManagementView.swift
@@ -26,7 +26,7 @@ struct TeamManagementView: View {
     ]
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
                     


### PR DESCRIPTION
## Summary
- reorder tabs in `ContentView`
- implement a simple feed list
- flesh out a basic settings screen
- wrap pages with `NavigationStack`
- cleanup layout of training, home, and team views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686e08229a98832494c8e980c1d5b6c9