### PR TITLE
Add pixel tree progress to home

### DIFF
--- a/Ballog/Models/SkillProgressModel.swift
+++ b/Ballog/Models/SkillProgressModel.swift
@@ -1,0 +1,50 @@
+//
+//  SkillProgressModel.swift
+//  Ballog
+//
+//  Created by OpenAI on 7/9/25.
+//
+
+import SwiftUI
+
+final class SkillProgressModel: ObservableObject {
+    enum Skill: String, CaseIterable, Identifiable {
+        case pass
+        case marseilleTurn
+        case twoOnePass
+        case shooting
+        case defense
+
+        var id: String { rawValue }
+    }
+
+    struct SkillInfo {
+        let color: Color
+        let positions: [(Int, Int)]
+    }
+
+    private let gridSize = 10
+
+    @Published var pixelGrid: [[Color]]
+    private var completedSkills: Set<Skill> = []
+
+    let skillInfos: [Skill: SkillInfo] = [
+        .pass: SkillInfo(color: .green, positions: [(2,4), (2,5), (1,4), (1,5)]),
+        .marseilleTurn: SkillInfo(color: .black, positions: [(4,4), (5,4), (6,4), (4,5), (5,5), (6,5)]),
+        .twoOnePass: SkillInfo(color: .brown, positions: [(7,3), (7,4), (7,5)]),
+        .shooting: SkillInfo(color: .red, positions: [(3,4), (3,5)]),
+        .defense: SkillInfo(color: .blue, positions: [(0,4), (0,5)])
+    ]
+
+    init() {
+        pixelGrid = Array(repeating: Array(repeating: Color.clear, count: gridSize), count: gridSize)
+    }
+
+    func complete(skill: Skill) {
+        guard !completedSkills.contains(skill), let info = skillInfos[skill] else { return }
+        completedSkills.insert(skill)
+        for pos in info.positions {
+            pixelGrid[pos.0][pos.1] = info.color
+        }
+    }
+}

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MainHomeView: View {
+    @StateObject private var progressModel = SkillProgressModel()
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -46,22 +48,9 @@ struct MainHomeView: View {
             .cornerRadius(12)
             .padding(.horizontal)
 
-            // 캐릭터 + 공풀장
-            ZStack {
-                Color.blue.opacity(0.1)
-                    .frame(height: 300)
-
-                VStack {
-                    Image(systemName: "teddybear.fill") // 곰돌이 아이콘 대체용
-                        .resizable()
-                        .frame(width: 120, height: 120)
-
-                    Text("내 캐릭터")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                }
-            }
-            .padding(.top, 16)
+            // 픽셀 트리 진행 뷰
+            PixelTreeView(model: progressModel)
+                .padding(.top, 16)
 
                 Spacer()
             }

--- a/Ballog/Views/PixelTreeView.swift
+++ b/Ballog/Views/PixelTreeView.swift
@@ -1,0 +1,42 @@
+//
+//  PixelTreeView.swift
+//  Ballog
+//
+//  Created by OpenAI on 7/9/25.
+//
+
+import SwiftUI
+
+struct PixelTreeView: View {
+    @ObservedObject var model: SkillProgressModel
+
+    var body: some View {
+        VStack(spacing: 12) {
+            PixelView(pixelColors: model.pixelGrid)
+            HStack {
+                ForEach(SkillProgressModel.Skill.allCases) { skill in
+                    Button(action: { model.complete(skill: skill) }) {
+                        Text(label(for: skill))
+                            .font(.caption)
+                            .padding(6)
+                            .background(RoundedRectangle(cornerRadius: 4).stroke())
+                    }
+                }
+            }
+        }
+    }
+
+    private func label(for skill: SkillProgressModel.Skill) -> String {
+        switch skill {
+        case .pass: return "패스"
+        case .marseilleTurn: return "마르세유턴"
+        case .twoOnePass: return "2대1"
+        case .shooting: return "슈팅"
+        case .defense: return "수비"
+        }
+    }
+}
+
+#Preview {
+    PixelTreeView(model: SkillProgressModel())
+}

--- a/Ballog/Views/PixelView.swift
+++ b/Ballog/Views/PixelView.swift
@@ -1,0 +1,30 @@
+//
+//  PixelView.swift
+//  Ballog
+//
+//  Created by OpenAI on 7/9/25.
+//
+
+import SwiftUI
+
+struct PixelView: View {
+    let pixelColors: [[Color]]
+    
+    var body: some View {
+        VStack(spacing: 2) {
+            ForEach(0..<pixelColors.count, id: \.self) { row in
+                HStack(spacing: 2) {
+                    ForEach(0..<pixelColors[row].count, id: \.self) { column in
+                        Rectangle()
+                            .fill(pixelColors[row][column])
+                            .frame(width: 16, height: 16)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PixelView(pixelColors: Array(repeating: Array(repeating: Color.green, count: 8), count: 8))
+}


### PR DESCRIPTION
## Summary
- introduce `SkillProgressModel` for tracking pixel positions per skill
- create `PixelView` and `PixelTreeView` to visualize training progress
- replace MainHomeView's character section with the new pixel tree view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686e290012708324bd77503d9ce48f59