### PR TITLE
Add MVVM structure for pixel tree

### DIFF
--- a/Ballog/Models/PixelTreeModel.swift
+++ b/Ballog/Models/PixelTreeModel.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+enum Skill: String, CaseIterable, Identifiable {
+    case pass
+    case marseilleTurn
+    case twoOnePass
+    case shooting
+    case defense
+
+    var id: String { rawValue }
+}
+
+struct SkillPixelInfo {
+    let color: Color
+    let positions: [(Int, Int)]
+}
+
+struct PixelTreeModel {
+    static let gridSize = 10
+    static let skills: [Skill: SkillPixelInfo] = [
+        .pass: SkillPixelInfo(color: .green, positions: [(2,4), (2,5), (1,4), (1,5)]),
+        .marseilleTurn: SkillPixelInfo(color: .black, positions: [(4,4), (5,4), (6,4), (4,5), (5,5), (6,5)]),
+        .twoOnePass: SkillPixelInfo(color: .brown, positions: [(7,3), (7,4), (7,5)]),
+        .shooting: SkillPixelInfo(color: .red, positions: [(3,4), (3,5)]),
+        .defense: SkillPixelInfo(color: .blue, positions: [(0,4), (0,5)])
+    ]
+}

--- a/Ballog/ViewModels/PixelTreeViewModel.swift
+++ b/Ballog/ViewModels/PixelTreeViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  PixelTreeViewModel.swift
+//  Ballog
+//
+//  Created by OpenAI on 7/9/25.
+//
+
+import SwiftUI
+
+final class PixelTreeViewModel: ObservableObject {
+    @Published var pixelGrid: [[Color]]
+    private var completedSkills: Set<Skill> = []
+
+    init() {
+        pixelGrid = Array(repeating: Array(repeating: Color.clear, count: PixelTreeModel.gridSize), count: PixelTreeModel.gridSize)
+    }
+
+    func complete(skill: Skill) {
+        guard !completedSkills.contains(skill), let info = PixelTreeModel.skills[skill] else { return }
+        completedSkills.insert(skill)
+        for pos in info.positions {
+            pixelGrid[pos.0][pos.1] = info.color
+        }
+    }
+}

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MainHomeView: View {
+    @StateObject private var pixelTreeViewModel = PixelTreeViewModel()
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -46,22 +48,9 @@ struct MainHomeView: View {
             .cornerRadius(12)
             .padding(.horizontal)
 
-            // 캐릭터 + 공풀장
-            ZStack {
-                Color.blue.opacity(0.1)
-                    .frame(height: 300)
-
-                VStack {
-                    Image(systemName: "teddybear.fill") // 곰돌이 아이콘 대체용
-                        .resizable()
-                        .frame(width: 120, height: 120)
-
-                    Text("내 캐릭터")
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                }
-            }
-            .padding(.top, 16)
+            // 픽셀 트리 진행 뷰
+            PixelTreeView(viewModel: pixelTreeViewModel)
+                .padding(.top, 16)
 
                 Spacer()
             }

--- a/Ballog/Views/PixelTreeView.swift
+++ b/Ballog/Views/PixelTreeView.swift
@@ -1,0 +1,42 @@
+//
+//  PixelTreeView.swift
+//  Ballog
+//
+//  Created by OpenAI on 7/9/25.
+//
+
+import SwiftUI
+
+struct PixelTreeView: View {
+    @ObservedObject var viewModel: PixelTreeViewModel
+
+    var body: some View {
+        VStack(spacing: 12) {
+            PixelView(pixelColors: viewModel.pixelGrid)
+            HStack {
+                ForEach(Skill.allCases) { skill in
+                    Button(action: { viewModel.complete(skill: skill) }) {
+                        Text(label(for: skill))
+                            .font(.caption)
+                            .padding(6)
+                            .background(RoundedRectangle(cornerRadius: 4).stroke())
+                    }
+                }
+            }
+        }
+    }
+
+    private func label(for skill: Skill) -> String {
+        switch skill {
+        case .pass: return "패스"
+        case .marseilleTurn: return "마르세유턴"
+        case .twoOnePass: return "2대1"
+        case .shooting: return "슈팅"
+        case .defense: return "수비"
+        }
+    }
+}
+
+#Preview {
+    PixelTreeView(viewModel: PixelTreeViewModel())
+}

--- a/Ballog/Views/PixelView.swift
+++ b/Ballog/Views/PixelView.swift
@@ -1,0 +1,30 @@
+//
+//  PixelView.swift
+//  Ballog
+//
+//  Created by OpenAI on 7/9/25.
+//
+
+import SwiftUI
+
+struct PixelView: View {
+    let pixelColors: [[Color]]
+    
+    var body: some View {
+        VStack(spacing: 2) {
+            ForEach(0..<pixelColors.count, id: \.self) { row in
+                HStack(spacing: 2) {
+                    ForEach(0..<pixelColors[row].count, id: \.self) { column in
+                        Rectangle()
+                            .fill(pixelColors[row][column])
+                            .frame(width: 16, height: 16)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PixelView(pixelColors: Array(repeating: Array(repeating: Color.green, count: 8), count: 8))
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is organized using the MVVM (Model-View-ViewModel) pattern.
 
 - `Ballog/App` - Application entry point
 - `Ballog/Models` - Model types
-- `Ballog/ViewModels` - ViewModel logic (currently empty)
+- `Ballog/ViewModels` - ViewModel logic
 - `Ballog/Views` - SwiftUI views
 - `Ballog/Assets.xcassets` - Assets used by the app
 - `Ballog/Ballog.entitlements` - App entitlements


### PR DESCRIPTION
## Summary
- organize pixel tree code into MVVM components
- introduce `PixelTreeModel` with color/position mapping for each skill
- create `PixelTreeViewModel` as the observable object
- update `PixelTreeView` and `MainHomeView` to use the new view model
- note the new ViewModels folder in README

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686e290012708324bd77503d9ce48f59