### PR TITLE
Update home view and pixel grid

### DIFF
--- a/Ballog/Models/SkillProgressModel.swift
+++ b/Ballog/Models/SkillProgressModel.swift
@@ -23,7 +23,7 @@ final class SkillProgressModel: ObservableObject {
         let positions: [(Int, Int)]
     }
 
-    private let gridSize = 10
+    private let gridSize = 8
 
     @Published var pixelGrid: [[Color]]
     private var completedSkills: Set<Skill> = []

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -37,24 +37,20 @@ struct MainHomeView: View {
                 }
                 .padding(.horizontal)
 
-                // 요일 패스 상태 박스
+                // 요일 상태 박스
                 HStack(spacing: 16) {
                     ForEach(["월", "화", "수", "목", "금"], id: \.self) { day in
-                        VStack {
-                            Text(day)
-                                .font(.subheadline)
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.gray, lineWidth: 1)
-                                .frame(width: 50, height: 50)
-                                .overlay(Text("패스").font(.caption))
-                        }
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray, lineWidth: 1)
+                            .frame(width: 50, height: 50)
+                            .overlay(Text(day).font(.subheadline))
                     }
                 }
                 .padding(.horizontal)
 
                 // 일지 리스트
                 let days = ["월", "화", "수", "목"]
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text("일지 리스트")
                         .font(.headline)
 
@@ -71,10 +67,12 @@ struct MainHomeView: View {
                                         .foregroundColor(.blue)
                                 }
                             }
-                            .padding(.vertical, 4)
+                            .padding(.vertical, 2)
                         }
                     }
                 }
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
                 .padding(.horizontal)
 
                 // 픽셀 트리 뷰

--- a/Ballog/Views/PixelTreeView.swift
+++ b/Ballog/Views/PixelTreeView.swift
@@ -11,10 +11,10 @@ struct PixelTreeView: View {
     @ObservedObject var model: SkillProgressModel
 
     var body: some View {
-        VStack(spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             PixelView(pixelColors: model.pixelGrid)
 
-            HStack {
+            VStack(alignment: .leading, spacing: 8) {
                 ForEach(SkillProgressModel.Skill.allCases, id: \.self) { skill in
                     Button(action: { model.complete(skill: skill) }) {
                         Text(label(for: skill))

--- a/Ballog/Views/PixelView.swift
+++ b/Ballog/Views/PixelView.swift
@@ -11,13 +11,14 @@ struct PixelView: View {
     let pixelColors: [[Color]]
     
     var body: some View {
-        VStack(spacing: 2) {
+        VStack(spacing: 1) {
             ForEach(0..<pixelColors.count, id: \.self) { row in
-                HStack(spacing: 2) {
+                HStack(spacing: 1) {
                     ForEach(0..<pixelColors[row].count, id: \.self) { column in
                         Rectangle()
-                            .fill(pixelColors[row][column])
+                            .fill(pixelColors[row][column] == Color.clear ? Color.white : pixelColors[row][column])
                             .frame(width: 16, height: 16)
+                            .overlay(Rectangle().stroke(Color.black, lineWidth: 0.5))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- embed day label inside each weekday card
- enclose journal list in a rounded frame and reduce its spacing
- display the pixel grid beside skill buttons vertically
- show empty pixels as white squares with a thin black border
- resize progress grid to 8x8

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686e3e079be08324a48b6ac5b88eb8df