### PR TITLE
Add Team List page with navigation link

### DIFF
--- a/Ballog/Views/TeamListView.swift
+++ b/Ballog/Views/TeamListView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+private enum Layout {
+    static let spacing = DesignConstants.spacing
+    static let padding = DesignConstants.horizontalPadding
+}
+
+struct TeamListView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.spacing) {
+            Text("My teams")
+                .font(.headline)
+                .padding(.top)
+
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.gray)
+                .frame(height: 80)
+                .overlay(
+                    HStack(spacing: 12) {
+                        Image(systemName: "soccerball")
+                            .resizable()
+                            .frame(width: 40, height: 40)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("해그래 FS")
+                                .fontWeight(.bold)
+                            Text("풋살팀")
+                            Text("플레이어 (플레이어-코치)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding()
+                )
+
+            Spacer()
+        }
+        .padding(Layout.padding)
+        .navigationTitle("팀 리스트")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark")
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {}) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .background(Color.pageBackground)
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    NavigationStack { TeamListView() }
+}

--- a/Ballog/Views/TeamManagementView.swift
+++ b/Ballog/Views/TeamManagementView.swift
@@ -40,9 +40,12 @@ struct TeamManagementView: View {
                         Image(systemName: "soccerball")
                             .resizable()
                             .frame(width: 30, height: 30)
-                        Text("해그래 FS")
-                            .font(.title)
-                            .fontWeight(.bold)
+                        NavigationLink(destination: TeamListView()) {
+                            Text("해그래 FS")
+                                .font(.title)
+                                .fontWeight(.bold)
+                        }
+                        .buttonStyle(.plain)
                         Spacer()
                     }
                     .padding(.horizontal, Layout.padding)


### PR DESCRIPTION
## Summary
- create new `TeamListView` to display existing teams
- link the team name on `TeamManagementView` to the team list page

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871075d80388324b2f2f16322197760