### PR TITLE
Add profile editing and team calendar

### DIFF
--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -21,6 +21,7 @@ struct DiaryDay {
 struct MainHomeView: View {
     @StateObject private var progressModel = SkillProgressModel()
     @State private var selectedDate: String? = nil
+    @AppStorage("profileMessage") private var profileMessage: String = "하나가 되어 정상을 향해가는 순간\n힘들어도 극복하면서 자신있게!! 나아가자!!"
     private var todayString: String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
@@ -33,7 +34,7 @@ struct MainHomeView: View {
             VStack(spacing: Layout.spacing) {
                 
                 // 상단 바
-                HStack {
+                HStack(spacing: 16) {
                     Text("볼터치")
                         .font(.title2)
                         .fontWeight(.bold)
@@ -41,35 +42,52 @@ struct MainHomeView: View {
 
                     Spacer()
 
-                    Button(action: {}) {
+                    NavigationLink(destination: ProfileView()) {
                         Image(systemName: "person.circle.fill")
                             .resizable()
-                            .frame(width: 32, height: 32)
-                            .padding(.trailing)
+                            .frame(width: 28, height: 28)
+                    }
+                    Button(action: {}) {
+                        Image(systemName: "bell")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                    }
+                    NavigationLink(destination: SettingsView()) {
+                        Image(systemName: "gearshape")
+                            .resizable()
+                            .frame(width: 24, height: 24)
                     }
                 }
                 .padding(.vertical, 8)
 
                 // 상단 메시지
-                VStack(spacing: 6) {
-                    Text("LET’S GO D-40")
-                        .font(.title)
-                        .bold()
-                    Text("하나가 되어 정상을 향해가는 순간\n힘들어도 극복하면서 자신있게!! 나아가자!!")
+                VStack(spacing: 8) {
+                    Text(profileMessage)
                         .font(.subheadline)
                         .multilineTextAlignment(.center)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.blue)
+                        )
+                    NavigationLink("수정") { ProfileView() }
+                        .font(.caption)
                 }
                 .padding(.horizontal)
 
-                    HStack(spacing: 16) {
-                        ForEach(["월", "화", "수", "목", "금"], id: \.self) { day in
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.gray, lineWidth: 1)
-                                .frame(width: 50, height: 50)
-                                .overlay(Text(day).font(.subheadline))
-                        }
+                    HStack {
+                        Text("캘린더")
+                            .font(.title2.bold())
+                        Spacer()
+                        Button(action: {}) { Image(systemName: "plus") }
                     }
                     .padding(.vertical, 12)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("- 제 2회 리드컵 풋살 대회 | D-day 40")
+                        Text("- 제 9회 펜타컵 풋살 대회 | D-day 35")
+                        Text("- [일정을 등록하세요]")
+                    }
+                    .font(.subheadline)
                 }
                 .padding(.horizontal)
 

--- a/Ballog/Views/ProfileView.swift
+++ b/Ballog/Views/ProfileView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("profileMessage") private var profileMessage: String = "하나가 되어 정상을 향해가는 순간\n힘들어도 극복하면서 자신있게!! 나아가자!!"
+
+    var body: some View {
+        Form {
+            Section(header: Text("응원 문구")) {
+                TextEditor(text: $profileMessage)
+                    .frame(height: 120)
+            }
+            Button("완료") { dismiss() }
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .navigationTitle("프로필 수정")
+    }
+}
+
+#Preview {
+    NavigationStack { ProfileView() }
+}

--- a/Ballog/Views/SimpleCalendarView.swift
+++ b/Ballog/Views/SimpleCalendarView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct SimpleCalendarView: View {
+    @Binding var selectedDate: Date?
+    var loggedDates: [Date]
+    private let calendar = Calendar.current
+
+    private var monthDays: [Date] {
+        let start = calendar.date(from: calendar.dateComponents([.year, .month], from: Date()))!
+        let range = calendar.range(of: .day, in: .month, for: start)!
+        return range.compactMap { calendar.date(byAdding: .day, value: $0 - 1, to: start) }
+    }
+
+    var body: some View {
+        let columns = Array(repeating: GridItem(.flexible()), count: 7)
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(monthDays, id: \.self) { date in
+                let day = calendar.component(.day, from: date)
+                Text("\(day)")
+                    .frame(maxWidth: .infinity, minHeight: 24)
+                    .background(
+                        Circle()
+                            .stroke(Color.red, lineWidth: 2)
+                            .opacity(loggedDates.contains { calendar.isDate($0, inSameDayAs: date) } ? 1 : 0)
+                    )
+                    .onTapGesture { selectedDate = date }
+            }
+        }
+    }
+}
+
+

--- a/Ballog/Views/TeamManagementView_hae.swift
+++ b/Ballog/Views/TeamManagementView_hae.swift
@@ -22,6 +22,13 @@ struct MyTeamMember: Identifiable {
 struct TeamManagementView_hae: View {
     // 선택된 팀원 정보 (팝업용)
     @State private var selectedMember: MyTeamMember? = nil
+    @State private var selectedDate: Date? = nil
+    @State private var showLog = false
+    private var loggedDates: [Date] {
+        let cal = Calendar.current
+        return [DateComponents(calendar: cal, year: 2025, month: 7, day: 4).date!,
+                DateComponents(calendar: cal, year: 2025, month: 7, day: 12).date!]
+    }
 
     // 팀원 리스트
     let teamMembers = [
@@ -80,6 +87,15 @@ struct TeamManagementView_hae: View {
                             }
                         }
                         .padding(.horizontal, Layout.padding)
+                    }
+
+                    SimpleCalendarView(selectedDate: $selectedDate, loggedDates: loggedDates)
+                        .padding()
+                    NavigationLink("", isActive: $showLog) {
+                        TeamTrainingLogView()
+                    }
+                    .onChange(of: selectedDate) { _ in
+                        if selectedDate != nil { showLog = true }
                     }
                     
                     // 4. 훈련 일정

--- a/Ballog/Views/TeamTrainingLogView.swift
+++ b/Ballog/Views/TeamTrainingLogView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct TeamTrainingLogView: View {
+    @State private var date = Date()
+    @State private var time = ""
+    @State private var location = ""
+    @State private var condition = 5
+    @State private var invited = ""
+    @State private var tactic = ""
+    @State private var skill = "아이솔레이션"
+    private let skills = ["아이솔레이션", "슛페이크 동작", "롤링드리블", "등딱턴"]
+    @State private var notes = ""
+
+    var body: some View {
+        Form {
+            DatePicker("날짜", selection: $date, displayedComponents: .date)
+            TextField("시간", text: $time)
+            TextField("장소", text: $location)
+            Stepper(value: $condition, in: 1...10) {
+                Text("컨디션: \(condition)")
+            }
+            TextField("같이 훈련한 팀원 초대", text: $invited)
+            TextField("팀 전술 훈련내용", text: $tactic)
+            Picker("기술 훈련", selection: $skill) {
+                ForEach(skills, id: \.self) { Text($0) }
+            }
+            Section(header: Text("배운점/느낀점")) {
+                TextEditor(text: $notes)
+                    .frame(height: 100)
+            }
+        }
+        .navigationTitle("팀 훈련일지")
+    }
+}
+
+#Preview {
+    NavigationStack { TeamTrainingLogView() }
+}


### PR DESCRIPTION
## Summary
- create **ProfileView** to edit the cheer message
- display profile message with edit button on MainHome
- add calendar heading with sample events on MainHome
- include profile, notification and settings icons
- implement **TeamTrainingLogView** for team log entry
- add simple calendar and log navigation in **TeamManagementView_hae**

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68711b0f603c832488378ece9f318224