### PR TITLE
Use system background color

### DIFF
--- a/Ballog/Extensions/Color+Theme.swift
+++ b/Ballog/Extensions/Color+Theme.swift
@@ -7,5 +7,5 @@ extension Color {
         let blue = Double(hex & 0xFF) / 255.0
         self.init(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
     }
-    static let pageBackground = Color.white
+    static let pageBackground = Color(.systemBackground)
 }


### PR DESCRIPTION
## Summary
- use dynamic page background color to support light/dark mode

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68711eceb1ec83249a4ffeedd00566c0