### PR TITLE
Fix date display and remove borders

### DIFF
--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -54,9 +54,14 @@ struct MainHomeView: View {
 
     private var topBar: some View {
         HStack(spacing: 16) {
-            Text("볼로그")
-                .font(.title2.bold())
-                .padding(.leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("볼로그")
+                    .font(.title2.bold())
+                Text(todayString)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.leading)
 
             Spacer()
 
@@ -85,10 +90,6 @@ struct MainHomeView: View {
                 .font(.subheadline)
                 .multilineTextAlignment(.center)
                 .padding()
-                .background {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.blue)
-                }
             NavigationLink("수정") { ProfileView() }
                 .font(.caption)
         }
@@ -118,10 +119,6 @@ struct MainHomeView: View {
                     }
                 }
             }
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.gray)
-            )
             .padding(.horizontal)
         }
     }
@@ -164,10 +161,6 @@ struct MainHomeView: View {
                     }
                 }
             }
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.gray)
-            )
             .padding(.horizontal)
         }
     }
@@ -219,9 +212,5 @@ struct DiaryDayView: View {
             }
         }
         .padding(Layout.padding)
-        .background {
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color.gray)
-        }
     }
 }

--- a/Ballog/Views/PixelView.swift
+++ b/Ballog/Views/PixelView.swift
@@ -18,7 +18,6 @@ struct PixelView: View {
                         Rectangle()
                             .fill(pixelColors[row][column] == Color.clear ? Color.white : pixelColors[row][column])
                             .frame(width: 16, height: 16)
-                            .overlay(Rectangle().stroke(Color.black, lineWidth: 0.5))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- show today's date under the title
- remove strokes around the profile message, schedule sections and diary view
- clean up pixel grid to remove per-cell borders

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871bb929c508324909958d7e885640b