### PR TITLE
Implement profile card and calendar improvements

### DIFF
--- a/Ballog/App/BallogApp.swift
+++ b/Ballog/App/BallogApp.swift
@@ -23,9 +23,18 @@ struct BallogApp: App {
         }
     }()
 
+    @StateObject private var attendanceStore = AttendanceStore()
+    @AppStorage("profileCard") private var storedCard: String = ""
+    @State private var showProfileCreator = false
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(attendanceStore)
+                .sheet(isPresented: $showProfileCreator) {
+                    ProfileCardCreationView()
+                }
+                .onAppear { if storedCard.isEmpty { showProfileCreator = true } }
         }
         .modelContainer(sharedModelContainer)
     }

--- a/Ballog/Models/AttendanceStore.swift
+++ b/Ballog/Models/AttendanceStore.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SwiftUI
+
+final class AttendanceStore: ObservableObject {
+    @Published var results: [Date: Bool] = [:]
+
+    func set(_ value: Bool, for date: Date) {
+        let day = Calendar.current.startOfDay(for: date)
+        results[day] = value
+    }
+}

--- a/Ballog/Models/ProfileCard.swift
+++ b/Ballog/Models/ProfileCard.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct ProfileCard: Codable {
+    var iconName: String
+    var nickname: String
+    var birthdate: Date
+    var hasTeam: Bool
+    var plapLevel: String
+    var athleteLevel: String
+}
+
+extension ProfileCard {
+    static let levels: [String] = [
+        "플랩 레벨없음", "비기너1", "비기너2", "비기너3", "비기너4", "비기너5",
+        "아마추어1", "아마추어2", "아마추어3", "아마추어4", "아마추어5",
+        "세미프로1", "세미프로2", "세미프로3", "세미프로4", "세미프로5",
+        "프로1", "프로2", "프로3", "프로4", "프로5"
+    ]
+
+    static let athleteLevels: [String] = [
+        "선출아님", "초등학교 선출", "중학교 선출", "고등학교 선출", "대학교 선출"
+    ]
+}

--- a/Ballog/Views/FeedView.swift
+++ b/Ballog/Views/FeedView.swift
@@ -2,8 +2,17 @@ import SwiftUI
 
 /// 피드 탭에서 팀 캘린더 매칭 기능을 보여준다.
 struct FeedView: View {
+    @EnvironmentObject private var attendanceStore: AttendanceStore
+
     var body: some View {
-        TeamCalendarView()
+        VStack {
+            TeamCalendarView()
+            if !attendanceStore.results.isEmpty {
+                List(attendanceStore.results.sorted(by: { $0.key < $1.key }), id: \\.key) { date, result in
+                    Text(date, style: .date) + Text(result ? " 참석" : " 불참")
+                }
+            }
+        }
     }
 }
 

--- a/Ballog/Views/InteractiveCalendarView.swift
+++ b/Ballog/Views/InteractiveCalendarView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct InteractiveCalendarView: View {
+    @Binding var selectedDate: Date?
+    @Binding var attendance: [Date: Bool]
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("팀 캘린더")
+                .font(.headline)
+            CalendarGrid(selectedDate: $selectedDate, attendance: $attendance)
+        }
+    }
+}
+
+private struct CalendarGrid: View {
+    @Binding var selectedDate: Date?
+    @Binding var attendance: [Date: Bool]
+    private let calendar = Calendar.current
+    private var monthDays: [Date] {
+        let start = calendar.date(from: calendar.dateComponents([.year, .month], from: Date()))!
+        let range = calendar.range(of: .day, in: .month, for: start)!
+        return range.compactMap { calendar.date(byAdding: .day, value: $0 - 1, to: start) }
+    }
+
+    var body: some View {
+        let columns = Array(repeating: GridItem(.flexible()), count: 7)
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(monthDays, id: \\.self) { date in
+                let day = calendar.component(.day, from: date)
+                VStack(spacing: 2) {
+                    Text("\(day)")
+                        .frame(maxWidth: .infinity)
+                    if calendar.component(.weekday, from: date) == 3 {
+                        Text("정기 훈련")
+                            .font(.caption2)
+                            .foregroundColor(.blue)
+                    }
+                    if let result = attendance[calendar.startOfDay(for: date)] {
+                        if result {
+                            Circle().fill(Color.green).frame(width: 8, height: 8)
+                        } else {
+                            Text("X").font(.caption2).foregroundColor(.red)
+                        }
+                    }
+                }
+                .onTapGesture { selectedDate = date }
+            }
+        }
+    }
+}

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -19,11 +19,16 @@ struct DiaryDay {
 }
 
 struct MainHomeView: View {
-    @StateObject private var progressModel = SkillProgressModel()
     @State private var selectedDate: String?
     @AppStorage("profileMessage")
     private var profileMessage: String =
         "하나가 되어 정상을 향해가는 순간\n힘들어도 극복하면서 자신있게!! 나아가자!!"
+    @AppStorage("profileCard") private var storedCard: String = ""
+
+    private var card: ProfileCard? {
+        guard let data = storedCard.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ProfileCard.self, from: data)
+    }
 
     private var todayString: String {
         let formatter = DateFormatter()
@@ -41,8 +46,12 @@ struct MainHomeView: View {
                 profileMessageSection
                 scheduleSection
                 thisWeekScheduleSection // 추가된 부분
-                PixelTreeView(model: progressModel)
-                    .padding(Layout.padding)
+                if let card = card {
+                    Image(card.iconName)
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                        .padding(Layout.padding)
+                }
 
                 Spacer()
             }

--- a/Ballog/Views/PersonalTrainingView.swift
+++ b/Ballog/Views/PersonalTrainingView.swift
@@ -13,9 +13,19 @@ private enum Layout {
 }
 
 struct PersonalTrainingView: View {
+    @AppStorage("profileCard") private var storedCard: String = ""
+
+    private var card: ProfileCard? {
+        guard let data = storedCard.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ProfileCard.self, from: data)
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: Layout.spacing) {
+                if let card = card {
+                    ProfileCardView(card: card)
+                }
                 // 상단 달력 헤더
                 HStack {
                     Text("2025년 7월")
@@ -92,7 +102,7 @@ struct PersonalTrainingView: View {
 
                 Spacer()
             }
-            .navigationTitle("개인 훈련")
+            .navigationTitle("")
         }
         .background(Color.pageBackground)
         .ignoresSafeArea()

--- a/Ballog/Views/ProfileCardCreationView.swift
+++ b/Ballog/Views/ProfileCardCreationView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct ProfileCardCreationView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var iconName: String = "fan"
+    @State private var nickname: String = ""
+    @State private var birthdate: Date = Date()
+    @State private var hasTeam: Bool = false
+    @State private var plapLevel: String = ProfileCard.levels.first ?? ""
+    @State private var athleteLevel: String = ProfileCard.athleteLevels.first ?? ""
+    @AppStorage("profileCard") private var storedCard: String = ""
+
+    private let icons = [
+        "fan", "football-player-2", "football-player-3", "goalkeeper",
+        "medal", "reading-1", "reading-2", "question", "soccer-player",
+        "reading-4"
+    ]
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 12) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(icons, id: \.self) { name in
+                            Image(name)
+                                .resizable()
+                                .frame(width: 60, height: 60)
+                                .padding(4)
+                                .background(iconName == name ? Color.blue.opacity(0.3) : Color.clear)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .onTapGesture { iconName = name }
+                        }
+                    }
+                }
+
+                TextField("닉네임", text: $nickname)
+                    .textFieldStyle(.roundedBorder)
+                DatePicker("태어난 날짜", selection: $birthdate, displayedComponents: .date)
+                Toggle("현재 소속팀이 있습니까?", isOn: $hasTeam)
+                Picker("플랩 레벨", selection: $plapLevel) {
+                    ForEach(ProfileCard.levels, id: \.self) { Text($0) }
+                }
+                Picker("선출 여부", selection: $athleteLevel) {
+                    ForEach(ProfileCard.athleteLevels, id: \.self) { Text($0) }
+                }
+
+                Button("저장하기") { save() }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding()
+            .navigationTitle("프로필 카드 작성")
+        }
+    }
+
+    private func save() {
+        let card = ProfileCard(iconName: iconName, nickname: nickname, birthdate: birthdate, hasTeam: hasTeam, plapLevel: plapLevel, athleteLevel: athleteLevel)
+        if let data = try? JSONEncoder().encode(card),
+           let json = String(data: data, encoding: .utf8) {
+            storedCard = json
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    ProfileCardCreationView()
+}

--- a/Ballog/Views/ProfileCardView.swift
+++ b/Ballog/Views/ProfileCardView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ProfileCardView: View {
+    let card: ProfileCard
+
+    var body: some View {
+        HStack(alignment: .top) {
+            Image(card.iconName)
+                .resizable()
+                .frame(width: 80, height: 80)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(card.nickname)
+                    .font(.title2.bold())
+                Text(card.birthdate, style: .date)
+                Text("소속팀: \(card.hasTeam ? "Y" : "N")")
+                Text("플랩 레벨: \(card.plapLevel)")
+                Text("선출 여부: \(card.athleteLevel)")
+            }
+            Spacer()
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).stroke())
+    }
+}
+
+#Preview {
+    ProfileCardView(card: ProfileCard(iconName: "fan", nickname: "홍길동", birthdate: Date(), hasTeam: true, plapLevel: "비기너1", athleteLevel: "선출아님"))
+}


### PR DESCRIPTION
## Summary
- introduce `AttendanceStore` for shared attendance data
- show profile card creation sheet on first launch
- display profile card in Personal Training and icon on Main Home
- implement interactive calendar with attendance marking
- allow attendance results to show in feed

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68720d50a5f48324b5a08df9bb82090c