### PR TITLE
Add team tabs and move card

### DIFF
--- a/Ballog/Views/ContentView.swift
+++ b/Ballog/Views/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
                     Text("개인")
                 }
 
-            TeamManagementView_hae()
+            TeamPageView()
                 .tabItem {
                     Image(systemName: "person.3.fill")
                     Text("팀")

--- a/Ballog/Views/FeedView.swift
+++ b/Ballog/Views/FeedView.swift
@@ -1,18 +1,9 @@
 import SwiftUI
 
-/// 피드 탭에서 팀 캘린더 매칭 기능을 보여준다.
+/// 피드 탭은 현재 준비 중이다.
 struct FeedView: View {
-    @EnvironmentObject private var attendanceStore: AttendanceStore
-
     var body: some View {
-        VStack {
-            TeamCalendarView()
-            if !attendanceStore.results.isEmpty {
-                List(attendanceStore.results.sorted(by: { $0.key < $1.key }), id: \.key) { date, result in
-                    Text(date, style: .date) + Text(result ? " 참석" : " 불참")
-                }
-            }
-        }
+        Text("피드 준비 중")
     }
 }
 

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -47,10 +47,7 @@ struct MainHomeView: View {
                 scheduleSection
                 thisWeekScheduleSection // 추가된 부분
                 if let card = card {
-                    Image(card.iconName)
-                        .resizable()
-                        .frame(width: 80, height: 80)
-                        .padding(Layout.padding)
+                    ProfileCardView(card: card, showIcon: false, showRecordButton: true)
                 }
 
                 Spacer()

--- a/Ballog/Views/MatchManagementView.swift
+++ b/Ballog/Views/MatchManagementView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// 팀 탭에서 매치 관리 기능을 보여준다.
+struct MatchManagementView: View {
+    @EnvironmentObject private var attendanceStore: AttendanceStore
+
+    var body: some View {
+        VStack {
+            TeamCalendarView()
+            if !attendanceStore.results.isEmpty {
+                List(attendanceStore.results.sorted(by: { $0.key < $1.key }), id: \.
+key) { date, result in
+                    Text(date, style: .date) + Text(result ? " 참석" : " 불참")
+                }
+            }
+        }
+        .navigationTitle("매치 관리")
+    }
+}
+
+#Preview {
+    MatchManagementView().environmentObject(AttendanceStore())
+}

--- a/Ballog/Views/PersonalTrainingView.swift
+++ b/Ballog/Views/PersonalTrainingView.swift
@@ -23,9 +23,6 @@ struct PersonalTrainingView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: Layout.spacing) {
-                if let card = card {
-                    ProfileCardView(card: card)
-                }
                 // 상단 달력 헤더
                 HStack {
                     Text("2025년 7월")

--- a/Ballog/Views/ProfileCardView.swift
+++ b/Ballog/Views/ProfileCardView.swift
@@ -2,21 +2,35 @@ import SwiftUI
 
 struct ProfileCardView: View {
     let card: ProfileCard
+    var showIcon: Bool = true
+    var showRecordButton: Bool = false
 
     var body: some View {
-        HStack(alignment: .top) {
-            Image(card.iconName)
-                .resizable()
-                .frame(width: 80, height: 80)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(card.nickname)
-                    .font(.title2.bold())
-                Text(card.birthdate, style: .date)
-                Text("소속팀: \(card.hasTeam ? "Y" : "N")")
-                Text("플랩 레벨: \(card.plapLevel)")
-                Text("선출 여부: \(card.athleteLevel)")
+        VStack(spacing: 8) {
+            HStack(alignment: .top) {
+                if showIcon {
+                    Image(card.iconName)
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(card.nickname)
+                        .font(.title2.bold())
+                    Text(card.birthdate, style: .date)
+                    Text("소속팀: \(card.hasTeam ? "Y" : "N")")
+                    Text("플랩 레벨: \(card.plapLevel)")
+                    Text("선출 여부: \(card.athleteLevel)")
+                }
+                Spacer()
             }
-            Spacer()
+
+            if showRecordButton {
+                NavigationLink(destination: PersonalTrainingView()) {
+                    Text("내훈련일지기록")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+            }
         }
         .padding()
         .background(RoundedRectangle(cornerRadius: 12).stroke())

--- a/Ballog/Views/TeamPageView.swift
+++ b/Ballog/Views/TeamPageView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+private enum TeamTab: String, CaseIterable {
+    case manage = "팀 관리"
+    case ranking = "팀 랭킹"
+    case match = "매치 관리"
+}
+
+struct TeamPageView: View {
+    @State private var selection: TeamTab = .manage
+
+    var body: some View {
+        VStack {
+            Picker("TeamTab", selection: $selection) {
+                ForEach(TeamTab.allCases, id: \.
+self) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            switch selection {
+            case .manage:
+                TeamManagementView_hae()
+            case .ranking:
+                TeamRankingView()
+            case .match:
+                MatchManagementView()
+            }
+        }
+    }
+}
+
+#Preview {
+    TeamPageView().environmentObject(AttendanceStore())
+}
+

--- a/Ballog/Views/TeamRankingView.swift
+++ b/Ballog/Views/TeamRankingView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct TeamRankingView: View {
+    var body: some View {
+        List {
+            Section(header: Text("지역 랭킹")) {
+                ForEach(1..<6) { rank in
+                    HStack {
+                        Text("\(rank)위")
+                        Spacer()
+                        Text("팀 \(rank)")
+                    }
+                }
+            }
+        }
+        .navigationTitle("팀 랭킹")
+    }
+}
+
+#Preview {
+    TeamRankingView()
+}


### PR DESCRIPTION
## Summary
- move personal character card to home and add a log button
- add segmented team page with ranking and match management
- move feed page content to new match management page and simplify feed

## Testing
- `swiftc -emit-module Ballog/Views/MatchManagementView.swift -o /tmp/test.o` *(fails: no such module SwiftUI)*

------
https://chatgpt.com/codex/tasks/task_e_68722334b9ec8324b1d18cc5cc6fe692