### PR TITLE
Fix profile card icon display

### DIFF
--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -47,7 +47,7 @@ struct MainHomeView: View {
                 scheduleSection
                 thisWeekScheduleSection // 추가된 부분
                 if let card = card {
-                    ProfileCardView(card: card, showIcon: false, showRecordButton: true)
+                    ProfileCardView(card: card, showIcon: true, iconOnRight: true, showRecordButton: true)
                 }
 
                 Spacer()

--- a/Ballog/Views/ProfileCardView.swift
+++ b/Ballog/Views/ProfileCardView.swift
@@ -3,12 +3,14 @@ import SwiftUI
 struct ProfileCardView: View {
     let card: ProfileCard
     var showIcon: Bool = true
+    /// When `true`, displays the icon on the trailing side of the card.
+    var iconOnRight: Bool = false
     var showRecordButton: Bool = false
 
     var body: some View {
         VStack(spacing: 8) {
             HStack(alignment: .top) {
-                if showIcon {
+                if showIcon && !iconOnRight {
                     Image(card.iconName)
                         .resizable()
                         .frame(width: 80, height: 80)
@@ -22,6 +24,11 @@ struct ProfileCardView: View {
                     Text("선출 여부: \(card.athleteLevel)")
                 }
                 Spacer()
+                if showIcon && iconOnRight {
+                    Image(card.iconName)
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                }
             }
 
             if showRecordButton {


### PR DESCRIPTION
## Summary
- let users optionally display profile card icons on the right side
- show the stored profile icon in the home screen

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872251549088324b980a277e24ccc1c