### PR TITLE
Implement personal calendar and training stats

### DIFF
--- a/Ballog/Views/InteractiveCalendarView.swift
+++ b/Ballog/Views/InteractiveCalendarView.swift
@@ -3,17 +3,27 @@ import SwiftUI
 struct InteractiveCalendarView: View {
     @Binding var selectedDate: Date?
     @Binding var attendance: [Date: Bool]
+    var title: String = "팀 캘린더"
+    @State private var showFullMonth = false
+
     var body: some View {
         VStack(alignment: .leading) {
-            Text("팀 캘린더")
-                .font(.headline)
+            HStack {
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                Button(showFullMonth ? "닫기" : "전체달력보기") {
+                    showFullMonth.toggle()
+                }
+                .font(.caption)
+            }
             DaysOfWeekHeader()
-            CalendarGrid(selectedDate: $selectedDate, attendance: $attendance)
+            CalendarGrid(selectedDate: $selectedDate, attendance: $attendance, showFullMonth: showFullMonth)
         }
     }
 }
 
-private struct DaysOfWeekHeader: View {
+struct DaysOfWeekHeader: View {
     private let days = ["일", "월", "화", "수", "목", "금", "토"]
 
     var body: some View {
@@ -27,20 +37,26 @@ private struct DaysOfWeekHeader: View {
     }
 }
 
-private struct CalendarGrid: View {
+struct CalendarGrid: View {
     @Binding var selectedDate: Date?
     @Binding var attendance: [Date: Bool]
+    var showFullMonth: Bool
     private let calendar = Calendar.current
     private var monthDays: [Date] {
         let start = calendar.date(from: calendar.dateComponents([.year, .month], from: Date()))!
         let range = calendar.range(of: .day, in: .month, for: start)!
         return range.compactMap { calendar.date(byAdding: .day, value: $0 - 1, to: start) }
     }
+    private var weekDays: [Date] {
+        let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: Date())!.start
+        return (0..<7).compactMap { calendar.date(byAdding: .day, value: $0, to: startOfWeek) }
+    }
+    private var days: [Date] { showFullMonth ? monthDays : weekDays }
 
     var body: some View {
         let columns = Array(repeating: GridItem(.flexible()), count: 7)
         LazyVGrid(columns: columns, spacing: 8) {
-            ForEach(monthDays, id: \.self) { date in
+            ForEach(days, id: \.self) { date in
                 let day = calendar.component(.day, from: date)
                 VStack(spacing: 2) {
                     Text("\(day)")

--- a/Ballog/Views/PersonalTrainingView.swift
+++ b/Ballog/Views/PersonalTrainingView.swift
@@ -15,6 +15,9 @@ private enum Layout {
 struct PersonalTrainingView: View {
     @AppStorage("profileCard") private var storedCard: String = ""
 
+    @State private var selectedDate: Date? = nil
+    @State private var attendance: [Date: Bool] = [:]
+
     private var card: ProfileCard? {
         guard let data = storedCard.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(ProfileCard.self, from: data)
@@ -23,20 +26,8 @@ struct PersonalTrainingView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: Layout.spacing) {
-                // 상단 달력 헤더
-                HStack {
-                    Text("2025년 7월")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                    Spacer()
-                    Button(action: {
-                        // 달력 전체 페이지 이동
-                    }) {
-                        Text("달력 보기")
-                            .foregroundColor(.blue)
-                    }
-                }
-                .padding(.horizontal, Layout.padding)
+                InteractiveCalendarView(selectedDate: $selectedDate, attendance: $attendance, title: "개인 캘린더")
+                    .padding(.horizontal, Layout.padding)
 
             // 훈련일지 작성 버튼
                 Button(action: {
@@ -89,8 +80,8 @@ struct PersonalTrainingView: View {
                             Text("유형별: 개인 6 / 팀 4 / 경기 2")
                         }
                     }
-                    Button("상세 통계 보기 →") {
-                        // 통계 페이지 이동
+                    NavigationLink(destination: TrainingStatisticsView()) {
+                        Text("상세 통계 보기 →")
                     }
                     .font(.caption)
                     .foregroundColor(.blue)

--- a/Ballog/Views/TeamManagementView_hae.swift
+++ b/Ballog/Views/TeamManagementView_hae.swift
@@ -73,25 +73,6 @@ struct TeamManagementView_hae: View {
                     
                     Divider()
                     
-                    // 3. 팀원 캐릭터
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 24) {
-                            ForEach(teamMembers) { member in
-                                VStack {
-                                    Image(systemName: "person.fill")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundColor(.blue)
-                                    Text(member.name)
-                                }
-                                .onTapGesture {
-                                    selectedMember = member
-                                }
-                            }
-                        }
-                        .padding(.horizontal, Layout.padding)
-                    }
-
                     InteractiveCalendarView(selectedDate: $selectedDate, attendance: $attendanceStore.results)
                         .padding()
                         .onChange(of: selectedDate) { _ in showOptions = selectedDate != nil }
@@ -167,7 +148,26 @@ struct TeamManagementView_hae: View {
                             .cornerRadius(10)
                     }
                     .padding(.horizontal, Layout.padding)
-                    
+
+                    // 팀원 캐릭터
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 24) {
+                            ForEach(teamMembers) { member in
+                                VStack {
+                                    Image(systemName: "person.fill")
+                                        .resizable()
+                                        .frame(width: 50, height: 50)
+                                        .foregroundColor(.blue)
+                                    Text(member.name)
+                                }
+                                .onTapGesture {
+                                    selectedMember = member
+                                }
+                            }
+                        }
+                        .padding(.horizontal, Layout.padding)
+                    }
+
                     Spacer()
                 }
             }

--- a/Ballog/Views/TrainingStatisticsView.swift
+++ b/Ballog/Views/TrainingStatisticsView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct TrainingStatisticsView: View {
+    private struct StatItem: Identifiable {
+        let id = UUID()
+        let label: String
+        let value: Double
+    }
+
+    private let totalCount = [StatItem(label: "2025", value: 20)]
+    private let skills = [
+        StatItem(label: "패스", value: 5),
+        StatItem(label: "슛", value: 3),
+        StatItem(label: "드리블", value: 4)
+    ]
+    private let totalTime = [StatItem(label: "시간", value: 15)]
+    private let types = [
+        StatItem(label: "개인", value: 6),
+        StatItem(label: "팀", value: 4),
+        StatItem(label: "경기", value: 2)
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: DesignConstants.spacing) {
+                StatChartSection(title: "총 횟수", data: totalCount)
+                StatChartSection(title: "기술별", data: skills)
+                StatChartSection(title: "총 시간", data: totalTime)
+                StatChartSection(title: "유형별", data: types)
+            }
+            .padding()
+        }
+        .navigationTitle("훈련 통계")
+    }
+}
+
+private struct StatChartSection: View {
+    let title: String
+    let data: [TrainingStatisticsView.StatItem]
+
+    private var maxValue: Double { data.map { $0.value }.max() ?? 1 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            ForEach(data) { item in
+                HStack {
+                    Text(item.label)
+                        .frame(width: 60, alignment: .leading)
+                    GeometryReader { geo in
+                        Rectangle()
+                            .fill(Color.blue)
+                            .frame(width: geo.size.width * item.value / maxValue, height: 8)
+                            .cornerRadius(4)
+                    }
+                }
+                .frame(height: 16)
+            }
+        }
+    }
+}
+
+#Preview {
+    TrainingStatisticsView()
+}


### PR DESCRIPTION
## Summary
- add an expandable calendar component
- move team members list to the bottom of the team page
- show a togglable calendar on the personal page
- create a new training statistics screen

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687227e9228c83248a428728e5e84190