### PR TITLE
Fix visibility for nested statistics type

### DIFF
--- a/Ballog/Views/TrainingStatisticsView.swift
+++ b/Ballog/Views/TrainingStatisticsView.swift
@@ -1,7 +1,12 @@
 import SwiftUI
 
 struct TrainingStatisticsView: View {
-    private struct StatItem: Identifiable {
+    // "StatItem" is referenced by "StatChartSection" which is defined below
+    // the enclosing view. The "private" access level restricts usage to this
+    // type only, leading to a compilation error. Use "fileprivate" so that
+    // the helper view in the same file can access it while keeping it internal
+    // to this file.
+    fileprivate struct StatItem: Identifiable {
         let id = UUID()
         let label: String
         let value: Double


### PR DESCRIPTION
## Summary
- allow `StatChartSection` to access `StatItem` by marking it `fileprivate`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68722b97fa8083248a447deffd17ec45