### PR TITLE
Implement team creation and join flow

### DIFF
--- a/Ballog/Views/TeamActionSelectionView.swift
+++ b/Ballog/Views/TeamActionSelectionView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct TeamActionSelectionView: View {
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+            NavigationLink("팀 만들기") {
+                TeamCreationView()
+            }
+            .buttonStyle(.borderedProminent)
+            NavigationLink("팀에 조인하기") {
+                TeamJoinView()
+            }
+            .buttonStyle(.bordered)
+            Spacer()
+        }
+        .navigationTitle("팀 설정")
+    }
+}
+
+#Preview {
+    NavigationStack { TeamActionSelectionView() }
+}

--- a/Ballog/Views/TeamCreationView.swift
+++ b/Ballog/Views/TeamCreationView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UIKit
+
+struct TeamCreationView: View {
+    private enum Step: Int { case name, sport, gender, type, source, done }
+    @State private var step: Step = .name
+
+    @State private var teamName = ""
+    @State private var sport = "풋살"
+    @State private var gender = "남자"
+    @State private var teamType = "club"
+    @State private var source = "인스타"
+
+    private let sports = ["풋살", "축구"]
+    private let genders = ["남자", "여자", "혼성"]
+    private let types = ["club", "회사 동호회", "Group of friends", "Recreational team", "School / University"]
+    private let sources = ["인스타", "지인 소개", "블로그", "인터넷 검색"]
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            switch step {
+            case .name:
+                Text("팀 이름 작성해주세요")
+                TextField("팀 이름", text: $teamName)
+                    .textFieldStyle(.roundedBorder)
+            case .sport:
+                Text("어떤 스포츠 인가요?")
+                Picker("스포츠", selection: $sport) {
+                    ForEach(sports, id: \..self) { Text($0) }
+                }
+                .pickerStyle(.segmented)
+            case .gender:
+                Text("팀의 성별이 어떻게 되나요?")
+                Picker("성별", selection: $gender) {
+                    ForEach(genders, id: \..self) { Text($0) }
+                }
+                .pickerStyle(.segmented)
+            case .type:
+                Text("어떤 타입의 팀인가요?")
+                Picker("타입", selection: $teamType) {
+                    ForEach(types, id: \..self) { Text($0) }
+                }
+            case .source:
+                Text("볼로그는 어떻게 알게 되었나요?")
+                Picker("경로", selection: $source) {
+                    ForEach(sources, id: \..self) { Text($0) }
+                }
+            case .done:
+                Text("축하합니다 팀 생성이 완료 되었어요!")
+                    .font(.headline)
+                Text("환영합니다 \(teamName) 님 !")
+                NavigationLink("멤버 추가하기") {
+                    TeamLinkShareView(teamName: teamName)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Spacer()
+            if step != .done {
+                Button("다음") { nextStep() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .navigationTitle("팀 만들기")
+    }
+
+    private func nextStep() {
+        if let next = Step(rawValue: step.rawValue + 1) {
+            step = next
+        }
+    }
+}
+
+#Preview {
+    NavigationStack { TeamCreationView() }
+}

--- a/Ballog/Views/TeamJoinView.swift
+++ b/Ballog/Views/TeamJoinView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct TeamJoinView: View {
+    @State private var code: String = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Text("팀 조인하기")
+                .font(.title2.bold())
+            TextField("팀 코드 입력", text: $code)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+            NavigationLink("조인") {
+                TeamManagementView_hae()
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("팀 조인")
+    }
+}
+
+#Preview {
+    NavigationStack { TeamJoinView() }
+}

--- a/Ballog/Views/TeamLinkShareView.swift
+++ b/Ballog/Views/TeamLinkShareView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import UIKit
+
+struct TeamLinkShareView: View {
+    let teamName: String
+    private let code: String = String(UUID().uuidString.prefix(8))
+    private var link: String { "https://ballog.app/team/\(code)" }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("팀 링크")
+                .font(.headline)
+            HStack {
+                Text(link)
+                    .font(.footnote)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Button(action: { UIPasteboard.general.string = link }) {
+                    Image(systemName: "doc.on.doc")
+                }
+            }
+            if let url = URL(string: link) {
+                ShareLink(item: url) {
+                    Text("공유하기")
+                }
+                .buttonStyle(.bordered)
+            }
+            Text("팀 코드: \(code)")
+        }
+        .padding()
+        .navigationTitle("팀 링크 공유")
+    }
+}
+
+#Preview {
+    NavigationStack { TeamLinkShareView(teamName: "해그래") }
+}

--- a/Ballog/Views/TeamListView.swift
+++ b/Ballog/Views/TeamListView.swift
@@ -7,6 +7,7 @@ private enum Layout {
 
 struct TeamListView: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var showAction = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.spacing) {
@@ -66,11 +67,14 @@ struct TeamListView: View {
             .navigationTitle("팀 리스트")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {}) {
+                    Button(action: { showAction = true }) {
                         Image(systemName: "plus")
                     }
                 }
             }
+            .background(
+                NavigationLink(destination: TeamActionSelectionView(), isActive: $showAction) { EmptyView() }
+            )
             .background(Color.pageBackground)
             .ignoresSafeArea()
         }

--- a/Ballog/Views/TeamManagementView_hae.swift
+++ b/Ballog/Views/TeamManagementView_hae.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 private enum Layout {
     static let spacing = DesignConstants.spacing
@@ -33,12 +34,35 @@ struct TeamManagementView_hae: View {
                 DateComponents(calendar: cal, year: 2025, month: 7, day: 12).date!]
     }
 
-    // 팀원 리스트
-    let teamMembers = [
-        MyTeamMember(name: "혜진"),
-        MyTeamMember(name: "규원"),
-        MyTeamMember(name: "진주")
-    ]
+    private var tuesdayDates: [Date] {
+        let calendar = Calendar.current
+        guard let first = calendar.nextDate(after: Date(), matching: DateComponents(weekday: 3), matchingPolicy: .nextTime) else { return [] }
+        return (0..<4).compactMap { calendar.date(byAdding: .day, value: 7 * $0, to: first) }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "M월 d일 (E)"
+        return f
+    }
+
+    @AppStorage("profileCard") private var storedCard: String = ""
+
+    private var userName: String {
+        guard let data = storedCard.data(using: .utf8),
+              let card = try? JSONDecoder().decode(ProfileCard.self, from: data) else { return "사용자" }
+        return card.nickname
+    }
+
+    private var teamMembers: [MyTeamMember] {
+        [
+            MyTeamMember(name: "혜진"),
+            MyTeamMember(name: "규원"),
+            MyTeamMember(name: "진주"),
+            MyTeamMember(name: userName)
+        ]
+    }
     
     var body: some View {
         NavigationStack {
@@ -100,11 +124,11 @@ struct TeamManagementView_hae: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("팀 정기 훈련 일정")
                             .font(.headline)
-                        ForEach(0..<4) { index in
+                        ForEach(tuesdayDates, id: \..self) { date in
                             HStack {
-                                Text("7월 \(20 + index)일 (일)")
+                                Text(dateFormatter.string(from: date))
                                 Spacer()
-                                Text("풋살장 A")
+                                Text("누누 풋살장")
                                 Spacer()
                                 Button("✅ 참석") {
                                     // 참석 처리

--- a/Ballog/Views/TeamManagementView_sis.swift
+++ b/Ballog/Views/TeamManagementView_sis.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 private enum Layout {
     static let spacing = DesignConstants.spacing
@@ -23,12 +24,35 @@ struct TeamManagementView_sis: View {
     // 선택된 팀원 정보 (팝업용)
     @State private var selectedMember: TeamMember? = nil
 
-    // 팀원 리스트
-    let teamMembers = [
-        TeamMember(name: "혜진"),
-        TeamMember(name: "영경"),
-        TeamMember(name: "희진")
-    ]
+    @AppStorage("profileCard") private var storedCard: String = ""
+
+    private var userName: String {
+        guard let data = storedCard.data(using: .utf8),
+              let card = try? JSONDecoder().decode(ProfileCard.self, from: data) else { return "사용자" }
+        return card.nickname
+    }
+
+    private var teamMembers: [TeamMember] {
+        [
+            TeamMember(name: "혜진"),
+            TeamMember(name: "영경"),
+            TeamMember(name: "희진"),
+            TeamMember(name: userName)
+        ]
+    }
+
+    private var tuesdayDates: [Date] {
+        let calendar = Calendar.current
+        guard let first = calendar.nextDate(after: Date(), matching: DateComponents(weekday: 3), matchingPolicy: .nextTime) else { return [] }
+        return (0..<4).compactMap { calendar.date(byAdding: .day, value: 7 * $0, to: first) }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "M월 d일 (E)"
+        return f
+    }
     
     var body: some View {
         NavigationStack {
@@ -86,11 +110,11 @@ struct TeamManagementView_sis: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("📅 팀 훈련 일정")
                             .font(.headline)
-                        ForEach(0..<4) { index in
+                        ForEach(tuesdayDates, id: \..self) { date in
                             HStack {
-                                Text("7월 \(20 + index)일 (일)")
+                                Text(dateFormatter.string(from: date))
                                 Spacer()
-                                Text("풋살장 A")
+                                Text("누누 풋살장")
                                 Spacer()
                                 Button("✅ 참석") {
                                     // 참석 처리


### PR DESCRIPTION
## Summary
- add TeamActionSelectionView for create/join choices
- implement multi step TeamCreationView
- provide sharing through TeamLinkShareView
- add TeamJoinView
- link new views from TeamListView
- display logged in user in team views
- show future Tuesday practices from calendar

## Testing
- `swiftc -parse Ballog/Views/TeamActionSelectionView.swift Ballog/Views/TeamCreationView.swift Ballog/Views/TeamLinkShareView.swift Ballog/Views/TeamJoinView.swift`
- `swiftc -parse Ballog/Views/TeamListView.swift Ballog/Views/TeamManagementView_hae.swift Ballog/Views/TeamManagementView_sis.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687231cf9b6c832498363b7e45451cd8