### PR TITLE
Display team logs from calendar

### DIFF
--- a/Ballog/App/BallogApp.swift
+++ b/Ballog/App/BallogApp.swift
@@ -24,6 +24,7 @@ struct BallogApp: App {
     }()
 
     @StateObject private var attendanceStore = AttendanceStore()
+    @StateObject private var logStore = TeamTrainingLogStore()
     @AppStorage("profileCard") private var storedCard: String = ""
     @State private var showProfileCreator = false
 
@@ -31,6 +32,7 @@ struct BallogApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(attendanceStore)
+                .environmentObject(logStore)
                 .sheet(isPresented: $showProfileCreator) {
                     ProfileCardCreationView()
                 }

--- a/Ballog/Models/TeamTrainingLog.swift
+++ b/Ballog/Models/TeamTrainingLog.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct TeamTrainingLog: Identifiable, Codable {
+    let id = UUID()
+    let date: Date
+    let tactic: String
+    let skill: String
+    let notes: String
+
+    var summary: String { "\(tactic) / \(skill)" }
+}

--- a/Ballog/Models/TeamTrainingLogStore.swift
+++ b/Ballog/Models/TeamTrainingLogStore.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class TeamTrainingLogStore: ObservableObject {
+    @Published private(set) var logs: [Date: [TeamTrainingLog]] = [:]
+    private let calendar = Calendar.current
+
+    func add(_ log: TeamTrainingLog) {
+        let day = calendar.startOfDay(for: log.date)
+        logs[day, default: []].append(log)
+    }
+}

--- a/Ballog/Views/ContentView.swift
+++ b/Ballog/Views/ContentView.swift
@@ -46,4 +46,6 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(AttendanceStore())
+        .environmentObject(TeamTrainingLogStore())
 }

--- a/Ballog/Views/TeamManagementView_hae.swift
+++ b/Ballog/Views/TeamManagementView_hae.swift
@@ -28,6 +28,7 @@ struct TeamManagementView_hae: View {
     @State private var showOptions = false
     @State private var showAttendance = false
     @EnvironmentObject private var attendanceStore: AttendanceStore
+    @EnvironmentObject private var logStore: TeamTrainingLogStore
     private var loggedDates: [Date] {
         let cal = Calendar.current
         return [DateComponents(calendar: cal, year: 2025, month: 7, day: 4).date!,
@@ -62,6 +63,11 @@ struct TeamManagementView_hae: View {
             MyTeamMember(name: "진주"),
             MyTeamMember(name: userName)
         ]
+    }
+
+    private var sortedLogs: [(Date, TeamTrainingLog)] {
+        logStore.logs.flatMap { day, logs in logs.map { (day, $0) } }
+            .sorted { $0.0 > $1.0 }
     }
     
     var body: some View {
@@ -118,6 +124,7 @@ struct TeamManagementView_hae: View {
                         }
                     NavigationLink("", isActive: $showLog) {
                         TeamTrainingLogView()
+                            .environmentObject(logStore)
                     }
                     
                     // 4. 훈련 일정
@@ -144,11 +151,11 @@ struct TeamManagementView_hae: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("📋 최근 팀 훈련 일지")
                             .font(.headline)
-                        ForEach(1..<6) { idx in
+                        ForEach(sortedLogs, id: \.1.id) { day, log in
                             HStack {
-                                Text("7월 \(14 + idx)일 • 전술 훈련")
+                                Text(dateFormatter.string(from: day))
                                 Spacer()
-                                Text("작성 완료")
+                                Text(log.summary)
                                     .font(.caption)
                                     .foregroundColor(.green)
                             }
@@ -164,7 +171,7 @@ struct TeamManagementView_hae: View {
                     
                     // 6. 작성 버튼
                     Button(action: {
-                        // 훈련일지 작성 페이지로 이동
+                        showLog = true
                     }) {
                         Text("✏️ 팀 훈련일지 작성")
                             .padding()

--- a/Ballog/Views/TeamPageView.swift
+++ b/Ballog/Views/TeamPageView.swift
@@ -30,6 +30,8 @@ struct TeamPageView: View {
 }
 
 #Preview {
-    TeamPageView().environmentObject(AttendanceStore())
+    TeamPageView()
+        .environmentObject(AttendanceStore())
+        .environmentObject(TeamTrainingLogStore())
 }
 

--- a/Ballog/Views/TeamTrainingLogView.swift
+++ b/Ballog/Views/TeamTrainingLogView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct TeamTrainingLogView: View {
+    @EnvironmentObject private var logStore: TeamTrainingLogStore
+    @Environment(\.dismiss) private var dismiss
     @State private var date = Date()
     @State private var time = ""
     @State private var location = ""
@@ -30,9 +32,17 @@ struct TeamTrainingLogView: View {
             }
         }
         .navigationTitle("팀 훈련일지")
+        .toolbar {
+            Button("저장") {
+                let log = TeamTrainingLog(date: date, tactic: tactic, skill: skill, notes: notes)
+                logStore.add(log)
+                dismiss()
+            }
+        }
     }
 }
 
 #Preview {
     NavigationStack { TeamTrainingLogView() }
+        .environmentObject(TeamTrainingLogStore())
 }


### PR DESCRIPTION
## Summary
- add simple training log model and store
- save new team logs in `TeamTrainingLogView`
- load recent logs in `TeamManagementView_hae`
- provide log store via environment objects and previews

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687257be2b6c8324bf22f94d15365abd