### PR TITLE
Implement tactics board and sliding training log cards

### DIFF
--- a/Ballog/Views/TacticsBoardView.swift
+++ b/Ballog/Views/TacticsBoardView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct TacticIcon: Identifiable {
+    let id = UUID()
+    let imageName: String
+    var color: Color = .primary
+    var position: CGPoint
+    var dashed: Bool = false
+}
+
+struct TacticsBoardView: View {
+    @State private var icons: [TacticIcon] = [
+        TacticIcon(imageName: "soccerball", position: CGPoint(x: 150, y: 150)),
+        // Red players
+        TacticIcon(imageName: "person.fill", color: .red, position: CGPoint(x: 50, y: 50)),
+        TacticIcon(imageName: "person.fill", color: .red, position: CGPoint(x: 50, y: 250)),
+        TacticIcon(imageName: "person.fill", color: .red, position: CGPoint(x: 100, y: 100)),
+        TacticIcon(imageName: "person.fill", color: .red, position: CGPoint(x: 100, y: 200)),
+        // Blue players
+        TacticIcon(imageName: "person.fill", color: .blue, position: CGPoint(x: 250, y: 50)),
+        TacticIcon(imageName: "person.fill", color: .blue, position: CGPoint(x: 250, y: 250)),
+        TacticIcon(imageName: "person.fill", color: .blue, position: CGPoint(x: 300, y: 100)),
+        TacticIcon(imageName: "person.fill", color: .blue, position: CGPoint(x: 300, y: 200))
+    ]
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                Image("tactics")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: geo.size.width, height: geo.size.width)
+
+                ForEach($icons) { $icon in
+                    Image(systemName: icon.imageName)
+                        .resizable()
+                        .foregroundColor(icon.color)
+                        .frame(width: 24, height: 24)
+                        .position(icon.position)
+                        .gesture(
+                            DragGesture()
+                                .onChanged { value in
+                                    icon.position = value.location
+                                }
+                        )
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.width)
+        }
+    }
+}
+
+#Preview {
+    TacticsBoardView()
+        .frame(width: 300, height: 300)
+}

--- a/Ballog/Views/TeamManagementView_hae.swift
+++ b/Ballog/Views/TeamManagementView_hae.swift
@@ -24,6 +24,7 @@ struct TeamManagementView_hae: View {
     // 선택된 팀원 정보 (팝업용)
     @State private var selectedMember: MyTeamMember? = nil
     @State private var selectedDate: Date? = nil
+    @State private var selectedLog: (Date, TeamTrainingLog)? = nil
     @State private var showLog = false
     @State private var showOptions = false
     @State private var showAttendance = false
@@ -151,21 +152,20 @@ struct TeamManagementView_hae: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("📋 최근 팀 훈련 일지")
                             .font(.headline)
-                        ForEach(sortedLogs, id: \.1.id) { day, log in
-                            HStack {
-                                Text(dateFormatter.string(from: day))
-                                Spacer()
-                                Text(log.summary)
-                                    .font(.caption)
-                                    .foregroundColor(.green)
+                        if sortedLogs.isEmpty {
+                            Text("잊지 말고 훈련내용을 기억하세요")
+                                .foregroundColor(.secondary)
+                        } else {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 16) {
+                                    ForEach(sortedLogs, id: \.1.id) { day, log in
+                                        TrainingLogCardView(day: day, log: log)
+                                            .onTapGesture { selectedLog = (day, log) }
+                                    }
+                                }
+                                .padding(.horizontal, Layout.padding)
                             }
-                            Divider()
                         }
-                        Button("전체 보기 →") {
-                            // 이동
-                        }
-                        .font(.caption)
-                        .foregroundColor(.blue)
                     }
                     .padding(.horizontal, Layout.padding)
                     
@@ -204,6 +204,9 @@ struct TeamManagementView_hae: View {
                 }
             }
             }
+        }
+        .sheet(item: $selectedLog) { data in
+            TrainingLogDetailView(day: data.0, log: data.1)
         }
     }
 

--- a/Ballog/Views/TeamTrainingLogView.swift
+++ b/Ballog/Views/TeamTrainingLogView.swift
@@ -23,6 +23,10 @@ struct TeamTrainingLogView: View {
             }
             TextField("같이 훈련한 팀원 초대", text: $invited)
             TextField("팀 전술 훈련내용", text: $tactic)
+            Section(header: Text("전술 보드")) {
+                TacticsBoardView()
+                    .frame(maxWidth: .infinity, minHeight: 300, maxHeight: 300)
+            }
             Picker("기술 훈련", selection: $skill) {
                 ForEach(skills, id: \.self) { Text($0) }
             }

--- a/Ballog/Views/TrainingLogViews.swift
+++ b/Ballog/Views/TrainingLogViews.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct TrainingLogCardView: View {
+    let day: Date
+    let log: TeamTrainingLog
+    private var formatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "M월 d일"
+        return f
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(formatter.string(from: day))
+                .font(.headline)
+            Text(log.summary)
+                .font(.caption)
+                .foregroundColor(.green)
+        }
+        .padding()
+        .frame(width: 160, height: 100)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.white))
+        .shadow(radius: 2)
+    }
+}
+
+struct TrainingLogDetailView: View {
+    let day: Date
+    let log: TeamTrainingLog
+    private var formatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "yyyy년 M월 d일"
+        return f
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(formatter.string(from: day))
+                .font(.title3)
+            Text("전술: \(log.tactic)")
+            Text("기술: \(log.skill)")
+            Text(log.notes)
+                .padding(.top, 8)
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    TrainingLogCardView(day: Date(), log: TeamTrainingLog(date: Date(), tactic: "패스", skill: "슛", notes: "메모"))
+}


### PR DESCRIPTION
## Summary
- show recent training logs in horizontally scrollable cards
- open full log in a sheet when card tapped
- display reminder when no logs exist
- add draggable tactics board for training log creation

## Testing
- `swiftc -parse Ballog/Views/TeamManagementView_hae.swift`
- `swiftc -parse Ballog/Views/TacticsBoardView.swift`


------
https://chatgpt.com/codex/tasks/task_e_68725c1884708324b2dbf95ca10bf636