### PR TITLE
Add pixel team character board

### DIFF
--- a/Ballog/Views/TeamCharacterBoardView.swift
+++ b/Ballog/Views/TeamCharacterBoardView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+private enum Layout {
+    static let padding = DesignConstants.horizontalPadding
+}
+
+struct TeamCharacter: Identifiable {
+    enum Pose: CaseIterable {
+        case wave
+        case victory
+
+        var emoji: String {
+            switch self {
+            case .wave: return "\u{1F44B}" // 👋
+            case .victory: return "\u{270C}\u{FE0F}" // ✌️
+            }
+        }
+    }
+
+    var id = UUID()
+    var name: String
+    var imageName: String
+    var isOnline: Bool
+    var pose: Pose = .wave
+}
+
+struct TeamCharacterBoardView: View {
+    let members: [TeamCharacter]
+    var onSelect: (TeamCharacter) -> Void = { _ in }
+    @State private var showField = false
+
+    private var columns: [GridItem] {
+        let count = members.count <= 3 ? members.count : 4
+        return Array(repeating: GridItem(.flexible(), spacing: 12), count: max(count, 3))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle("축구장 배경", isOn: $showField)
+                .padding(.horizontal, Layout.padding)
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(showField ? Color.green.opacity(0.2) : Color(UIColor.systemGray6))
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(members) { member in
+                        VStack(spacing: 4) {
+                            ZStack(alignment: .topTrailing) {
+                                Image(member.imageName)
+                                    .resizable()
+                                    .frame(width: 60, height: 60)
+                                Text(member.pose.emoji)
+                                    .offset(x: 6, y: -6)
+                            }
+                            HStack(spacing: 4) {
+                                Text(member.name)
+                                if member.isOnline {
+                                    Circle()
+                                        .fill(Color.green)
+                                        .frame(width: 6, height: 6)
+                                }
+                            }
+                            .font(.caption)
+                        }
+                        .onTapGesture { onSelect(member) }
+                    }
+                    Image(systemName: "leaf.fill")
+                        .font(.title)
+                        .foregroundColor(.green)
+                    if members.count > 4 {
+                        Image(systemName: "lamp.table.fill")
+                            .font(.title2)
+                            .foregroundColor(.yellow)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    TeamCharacterBoardView(members: [
+        TeamCharacter(name: "샘플1", imageName: "soccer-player", isOnline: true),
+        TeamCharacter(name: "샘플2", imageName: "football-player-2", isOnline: false, pose: .victory),
+        TeamCharacter(name: "샘플3", imageName: "football-player-3", isOnline: true)
+    ])
+}

--- a/Ballog/Views/TeamManagementView_hae.swift
+++ b/Ballog/Views/TeamManagementView_hae.swift
@@ -17,6 +17,9 @@ private enum Layout {
 struct MyTeamMember: Identifiable {
     var id = UUID()
     var name: String
+    var imageName: String = "soccer-player"
+    var isOnline: Bool = false
+    var pose: TeamCharacter.Pose = .wave
 }
 // MARK: - 모델 구조 추가
 
@@ -74,10 +77,10 @@ struct TeamManagementView_hae: View {
     
     private var teamMembers: [MyTeamMember] {
         [
-            MyTeamMember(name: "혜진"),
-            MyTeamMember(name: "규원"),
-            MyTeamMember(name: "진주"),
-            MyTeamMember(name: userName)
+            MyTeamMember(name: "혜진", imageName: "football-player-2", isOnline: true),
+            MyTeamMember(name: "규원", imageName: "football-player-3", isOnline: false, pose: .victory),
+            MyTeamMember(name: "진주", imageName: "goalkeeper", isOnline: true),
+            MyTeamMember(name: userName, imageName: "soccer-player", isOnline: false)
         ]
     }
     
@@ -92,6 +95,9 @@ struct TeamManagementView_hae: View {
                 VStack(spacing: Layout.spacing) {
                     TeamHeaderView()
                     TeamQuoteView()
+                    TeamCharacterBoardView(members: teamMembers) { member in
+                        selectedMember = member
+                    }
                     Divider()
                     CalendarSection(selectedDate: $selectedDate,
                                     showLog: $showLog,
@@ -106,9 +112,6 @@ struct TeamManagementView_hae: View {
                         selectedLog = SelectedTeamLog(day: day, log: log)
                     }
                     WriteLogButton { showLog = true }
-                    TeamMembersSection(members: teamMembers) { member in
-                        selectedMember = member
-                    }
                     Spacer()
                 }
             }
@@ -249,30 +252,6 @@ struct TeamManagementView_hae: View {
             .padding(.horizontal, Layout.padding)
         }
     }
-    
-    private struct TeamMembersSection: View {
-        let members: [MyTeamMember]
-        var onSelect: (MyTeamMember) -> Void
-        
-        var body: some View {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 24) {
-                    ForEach(members) { member in
-                        VStack {
-                            Image(systemName: "person.fill")
-                                .resizable()
-                                .frame(width: 50, height: 50)
-                                .foregroundColor(.blue)
-                            Text(member.name)
-                        }
-                        .onTapGesture { onSelect(member) }
-                    }
-                }
-                .padding(.horizontal, Layout.padding)
-            }
-        }
-    }
-    
     
     // MARK: - 팝업: 팀원 캐릭터 카드
     struct MyTeamMemberCardView: View {


### PR DESCRIPTION
## Summary
- display character board between team quote and calendar
- remove bottom member icon section
- create `TeamCharacterBoardView` supporting optional soccer field background
- extend `MyTeamMember` model with pose, image and online state

## Testing
- `swift --version`
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687264310a80832497b97d891db0878d