### PR TITLE
Improve tactics board drag and add weather backgrounds

### DIFF
--- a/Ballog/Models/WeatherService.swift
+++ b/Ballog/Models/WeatherService.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum WeatherCondition: String, CaseIterable {
+    case sunny
+    case rain
+    case snow
+    case clear
+
+    var imageName: String? {
+        switch self {
+        case .sunny: return "sunny"
+        case .rain: return "rain"
+        case .snow: return "snow"
+        case .clear: return nil
+        }
+    }
+}
+
+struct WeatherService {
+    static func weather(for date: Date) -> WeatherCondition {
+        let day = Calendar.current.component(.day, from: date)
+        switch day % 3 {
+        case 0: return .sunny
+        case 1: return .rain
+        default: return .snow
+        }
+    }
+}

--- a/Ballog/Views/TeamCharacterBoardView.swift
+++ b/Ballog/Views/TeamCharacterBoardView.swift
@@ -27,6 +27,7 @@ struct TeamCharacter: Identifiable {
 struct TeamCharacterBoardView: View {
     let members: [TeamCharacter]
     var onSelect: (TeamCharacter) -> Void = { _ in }
+    var backgroundImage: String?
     @State private var showField = false
 
     private var columns: [GridItem] {
@@ -39,6 +40,13 @@ struct TeamCharacterBoardView: View {
             Toggle("축구장 배경", isOn: $showField)
                 .padding(.horizontal, Layout.padding)
             ZStack {
+                if let bg = backgroundImage {
+                    Image(bg)
+                        .resizable()
+                        .scaledToFill()
+                        .opacity(0.3)
+                        .clipped()
+                }
                 RoundedRectangle(cornerRadius: 12)
                     .fill(showField ? Color.green.opacity(0.2) : Color(UIColor.systemGray6))
                 LazyVGrid(columns: columns, spacing: 16) {
@@ -83,5 +91,5 @@ struct TeamCharacterBoardView: View {
         TeamCharacter(name: "샘플1", imageName: "soccer-player", isOnline: true),
         TeamCharacter(name: "샘플2", imageName: "football-player-2", isOnline: false, pose: .victory),
         TeamCharacter(name: "샘플3", imageName: "football-player-3", isOnline: true)
-    ])
+    ], backgroundImage: "summer")
 }


### PR DESCRIPTION
## Summary
- reset tactics board state on appear
- allow dragging players without drawing lines
- show weather-based background images for team characters
- display weather icons on training schedule
- add simple WeatherService

## Testing
- `swift --version`
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68726ecfbff88324a3b1a5ef1a9a3c97