### PR TITLE
Implement calendar sync and improved login

### DIFF
--- a/Ballog/Models/TeamEvent.swift
+++ b/Ballog/Models/TeamEvent.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct TeamEvent: Identifiable, Codable {
+    enum EventType: String, Codable { case match, training }
+    let id = UUID()
+    var date: Date
+    var title: String
+    var place: String
+    var type: EventType
+}
+
+final class TeamEventStore: ObservableObject {
+    @Published var events: [TeamEvent] = []
+
+    func add(_ event: TeamEvent) {
+        events.append(event)
+    }
+}

--- a/Ballog/Views/LoginView.swift
+++ b/Ballog/Views/LoginView.swift
@@ -2,10 +2,23 @@ import SwiftUI
 
 struct LoginView: View {
     @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
-    @AppStorage("hasTeam") private var hasTeam: Bool = true
+    @AppStorage("hasTeam") private var hasTeam: Bool = false
+    @AppStorage("savedUsername") private var savedUsername: String = ""
+    @AppStorage("savedPassword") private var savedPassword: String = ""
+    @AppStorage("rememberID") private var rememberID: Bool = false
+    @AppStorage("autoLogin") private var autoLogin: Bool = false
+    @AppStorage("accounts") private var storedAccountsData: Data = Data()
+
     @State private var username: String = ""
     @State private var password: String = ""
-    @State private var teamOption: Bool = true
+    @State private var showSignup = false
+    @State private var alertMessage = ""
+    @State private var showAlert = false
+
+    private var accounts: [String: Account] {
+        get { (try? JSONDecoder().decode([String: Account].self, from: storedAccountsData)) ?? [:] }
+        set { storedAccountsData = (try? JSONEncoder().encode(newValue)) ?? Data() }
+    }
 
     var body: some View {
         VStack(spacing: 20) {
@@ -16,16 +29,58 @@ struct LoginView: View {
                 .textFieldStyle(.roundedBorder)
             SecureField("비밀번호", text: $password)
                 .textFieldStyle(.roundedBorder)
-            Toggle("팀이 이미 있어요", isOn: $teamOption)
-                .toggleStyle(.switch)
-            Button("로그인") {
-                isLoggedIn = true
-                hasTeam = teamOption
+            Toggle("자동 로그인", isOn: $autoLogin)
+            Toggle("아이디 저장", isOn: $rememberID)
+            HStack {
+                Button("로그인") { attemptLogin() }
+                    .buttonStyle(.borderedProminent)
+                Button("회원가입") { showSignup = true }
+                    .buttonStyle(.bordered)
             }
-            .buttonStyle(.borderedProminent)
             Spacer()
         }
         .padding()
+        .onAppear { applySavedInfo() }
+        .alert(alertMessage, isPresented: $showAlert) { Button("확인", role: .cancel) {} }
+        .sheet(isPresented: $showSignup) { SignUpView() }
+    }
+
+    private func applySavedInfo() {
+        if rememberID {
+            username = savedUsername
+        }
+        if autoLogin {
+            username = savedUsername
+            password = savedPassword
+            if let account = accounts[username], account.password == password {
+                isLoggedIn = true
+            }
+        }
+    }
+
+    private func attemptLogin() {
+        guard !username.isEmpty, !password.isEmpty else {
+            alertMessage = "아이디와 비밀번호를 입력해주세요"
+            showAlert = true
+            return
+        }
+
+        guard let account = accounts[username] else {
+            alertMessage = "아이디가 존재하지 않습니다 회원가입 하시겠습니까?"
+            showAlert = true
+            showSignup = true
+            return
+        }
+
+        guard account.password == password else {
+            alertMessage = "비밀번호가 틀렸습니다"
+            showAlert = true
+            return
+        }
+
+        if rememberID { savedUsername = username } else { savedUsername = "" }
+        if autoLogin { savedPassword = password } else { savedPassword = "" }
+        isLoggedIn = true
     }
 }
 

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -57,6 +57,34 @@ struct MainHomeView: View {
         return formatter.string(from: Date())
     }
 
+    private var competitionEvents: [TeamEvent] {
+        eventStore.events.filter { $0.type == .match }.sorted { $0.date < $1.date }
+    }
+
+    private var thisWeekEvents: [TeamEvent] {
+        eventStore.events.filter {
+            calendar.isDate($0.date, equalTo: Date(), toGranularity: .weekOfYear)
+        }.sorted { $0.date < $1.date }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "M월 d일"
+        return f
+    }
+
+    private var timeFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }
+
+    private func dDay(from date: Date) -> Int {
+        let diff = calendar.dateComponents([.day], from: calendar.startOfDay(for: Date()), to: calendar.startOfDay(for: date))
+        return diff.day ?? 0
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: Layout.spacing) {
@@ -127,31 +155,27 @@ struct MainHomeView: View {
                 Text("대회 일정")
                     .font(.title2.bold())
                 Spacer()
-                Button(action: {}) {
-                    Image(systemName: "plus")
-                }
             }
             .padding(.horizontal)
 
             VStack(alignment: .leading, spacing: 0) {
-                ForEach(scheduleTexts.indices, id: \.self) { index in
-                    Text(scheduleTexts[index])
+                if competitionEvents.isEmpty {
+                    Text("등록된 일정이 없습니다")
                         .padding(.vertical, 12)
                         .padding(.horizontal)
-
-                    if index != scheduleTexts.count - 1 {
-                        Divider()
+                } else {
+                    ForEach(competitionEvents) { event in
+                        Text("- \(dateFormatter.string(from: event.date)) \(event.title) | D-day \(dDay(from: event.date))")
+                            .padding(.vertical, 12)
+                            .padding(.horizontal)
+                        if event.id != competitionEvents.last?.id {
+                            Divider()
+                        }
                     }
                 }
             }
             .padding(.horizontal)
         }
-    }
-
-    private var scheduleTexts: [String] {
-        [
-            "- 제 2회 리드컵 풋살 대회 | D-day 40",
-            "- 제 9회 펜타컵 풋살 대회 | D-day 35"        ]
     }
 
     private var thisWeekScheduleSection: some View {
@@ -160,46 +184,32 @@ struct MainHomeView: View {
                 Text("이번주 일정")
                     .font(.title2.bold())
                 Spacer()
-                Button(action: {}) {
-                    Image(systemName: "plus")
-                }
             }
             .padding(.horizontal)
 
             VStack(alignment: .leading, spacing: 0) {
-                ForEach(sampleDiaryDay.entries.indices, id: \.self) { index in
-                    let entry = sampleDiaryDay.entries[index]
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("- \(entry.title) | \(entry.time)")
-                        Text("  장소: \(entry.place)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.vertical, 12)
-                    .padding(.horizontal)
-
-                    if index != sampleDiaryDay.entries.count - 1 {
-                        Divider()
+                if thisWeekEvents.isEmpty {
+                    Text("등록된 일정이 없습니다")
+                        .padding(.vertical, 12)
+                        .padding(.horizontal)
+                } else {
+                    ForEach(thisWeekEvents) { event in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("- \(timeFormatter.string(from: event.date)) | \(event.title)")
+                            Text("  장소: \(event.place)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 12)
+                        .padding(.horizontal)
+                        if event.id != thisWeekEvents.last?.id {
+                            Divider()
+                        }
                     }
                 }
             }
             .padding(.horizontal)
         }
-    }
-
-    private var sampleDiaryDay: DiaryDay {
-        DiaryDay(
-            date: "06 (화)",
-            entries: [
-                DiaryEntry(
-                    color: .green,
-                    time: "20:00 - 22:00",
-                    title: "해그래 운동",
-                    place: "서수원풋살장"
-                )
-            ]
-        )
     }
 }
 

--- a/Ballog/Views/SignUpView.swift
+++ b/Ballog/Views/SignUpView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct SignUpView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var username = ""
+    @State private var password = ""
+    @State private var email = ""
+    @AppStorage("accounts") private var storedAccountsData: Data = Data()
+
+    private var accounts: [String: Account] {
+        get { (try? JSONDecoder().decode([String: Account].self, from: storedAccountsData)) ?? [:] }
+        set { storedAccountsData = (try? JSONEncoder().encode(newValue)) ?? Data() }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("아이디", text: $username)
+                SecureField("비밀번호", text: $password)
+                TextField("이메일", text: $email)
+            }
+            .navigationTitle("회원가입")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("완료") { register() }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func register() {
+        guard !username.isEmpty, !password.isEmpty, !email.isEmpty else { return }
+        var dict = accounts
+        dict[username] = Account(username: username, password: password, email: email)
+        accounts = dict
+        dismiss()
+    }
+}
+
+struct Account: Codable {
+    var username: String
+    var password: String
+    var email: String
+}
+
+#Preview {
+    SignUpView()
+}
+

--- a/Ballog/Views/TeamCalendarView.swift
+++ b/Ballog/Views/TeamCalendarView.swift
@@ -102,6 +102,7 @@ struct TeamCalendarView: View {
     @State private var selectedAvailability: Availability?
     @State private var showCourtSheet = false
     @State private var showPublicMatchList = false
+    @EnvironmentObject private var eventStore: TeamEventStore
     
     var body: some View {
         NavigationStack {
@@ -148,7 +149,30 @@ struct TeamCalendarView: View {
             .alert(item: $viewModel.confirmedMatch) { match in
                 Alert(title: Text("매치 확정!"), message: Text("날짜: \(match.date)\n시간: \(match.timeRange)\n구장: \(match.court.name)\n팀: \(match.teamA) vs \(match.teamB ?? "?")"), dismissButton: .default(Text("확인")))
             }
+            .onChange(of: viewModel.confirmedMatch) { match in
+                if let match = match,
+                   let date = Self.date(from: match.date, timeRange: match.timeRange) {
+                    let title = "매치 \(match.teamA) vs \(match.teamB ?? "?")"
+                    let event = TeamEvent(date: date, title: title, place: match.court.name, type: .match)
+                    eventStore.add(event)
+                }
+            }
         }
+    }
+
+    private static func date(from day: String, timeRange: String) -> Date? {
+        let map = ["일요일":1, "월요일":2, "화요일":3, "수요일":4, "목요일":5, "금요일":6, "토요일":7]
+        guard let weekday = map[day] else { return nil }
+        let startTime = timeRange.split(separator: "~").first ?? "00:00"
+        let comps = startTime.split(separator: ":")
+        guard comps.count == 2,
+              let hour = Int(comps[0]),
+              let minute = Int(comps[1]) else { return nil }
+        var dateComponents = DateComponents()
+        dateComponents.weekday = weekday
+        dateComponents.hour = hour
+        dateComponents.minute = minute
+        return Calendar.current.nextDate(after: Date(), matching: dateComponents, matchingPolicy: .nextTimePreservingSmallerComponents)
     }
 }
 

--- a/Ballog/Views/TeamManagementView.swift
+++ b/Ballog/Views/TeamManagementView.swift
@@ -51,6 +51,7 @@ struct TeamManagementView: View {
     @State private var showAttendance = false
     @EnvironmentObject private var attendanceStore: AttendanceStore
     @EnvironmentObject private var logStore: TeamTrainingLogStore
+    @EnvironmentObject private var eventStore: TeamEventStore
     @State private var trainingWeather: WeatherCondition = .clear
     
     private var tuesdayDates: [Date] {
@@ -127,6 +128,12 @@ struct TeamManagementView: View {
         .onAppear {
             if let next = tuesdayDates.first {
                 trainingWeather = WeatherService.weather(for: next)
+            }
+            if eventStore.events.isEmpty {
+                let events = tuesdayDates.map { date in
+                    TeamEvent(date: date, title: "정기 훈련", place: "누누 풋살장", type: .training)
+                }
+                eventStore.events.append(contentsOf: events)
             }
         }
         .sheet(item: $selectedLog) { data in


### PR DESCRIPTION
## Summary
- add `TeamEvent` and global `TeamEventStore`
- sync team calendar events to main home view
- remove team option on login and support saved credentials
- add signup flow and automatic login if enabled
- persist sample team training events

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68735e0662908324b84cf45a86fc328e