### PR TITLE
Fix mutating setter in SignUpView

### DIFF
--- a/Ballog/Views/SignUpView.swift
+++ b/Ballog/Views/SignUpView.swift
@@ -8,8 +8,13 @@ struct SignUpView: View {
     @AppStorage("accounts") private var storedAccountsData: Data = Data()
 
     private var accounts: [String: Account] {
-        get { (try? JSONDecoder().decode([String: Account].self, from: storedAccountsData)) ?? [:] }
-        set { storedAccountsData = (try? JSONEncoder().encode(newValue)) ?? Data() }
+        get {
+            (try? JSONDecoder().decode([String: Account].self,
+                                        from: storedAccountsData)) ?? [:]
+        }
+        nonmutating set {
+            storedAccountsData = (try? JSONEncoder().encode(newValue)) ?? Data()
+        }
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- update the `accounts` computed property to have a `nonmutating set`

This lets the `register()` method modify the stored accounts without marking the method itself as mutating, avoiding the "self is immutable" error.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687361d4cb648324993035c16f483f6d