### PR TITLE
Fix MainHomeView errors

### DIFF
--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -19,6 +19,8 @@ struct DiaryDay {
 }
 
 struct MainHomeView: View {
+    @EnvironmentObject private var eventStore: TeamEventStore
+    private let calendar = Calendar.current
     @State private var selectedDate: String?
     private let quotes = [
         "노력은 배신하지 않는다. – 일본 야구선수 이치로",


### PR DESCRIPTION
## Summary
- add missing `eventStore` environment object and `calendar` constant in `MainHomeView`

## Testing
- `swift test` *(fails: Package.swift missing)*
- `swiftc Ballog/Views/MainHomeView.swift -o /tmp/test` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687363c9de2083249af4d18cd4975bf5