### PR TITLE
Add Core Data signup storage

### DIFF
--- a/Ballog/Models/AccountEntity.swift
+++ b/Ballog/Models/AccountEntity.swift
@@ -1,0 +1,15 @@
+import Foundation
+import CoreData
+
+@objc(AccountEntity)
+final class AccountEntity: NSManagedObject {
+    @NSManaged var username: String
+    @NSManaged var password: String
+    @NSManaged var email: String
+}
+
+extension AccountEntity {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<AccountEntity> {
+        NSFetchRequest<AccountEntity>(entityName: "AccountEntity")
+    }
+}

--- a/Ballog/Utilities/CoreDataStack.swift
+++ b/Ballog/Utilities/CoreDataStack.swift
@@ -1,0 +1,60 @@
+import Foundation
+import CoreData
+
+final class CoreDataStack {
+    static let shared = CoreDataStack()
+
+    let container: NSPersistentContainer
+
+    private init(inMemory: Bool = false) {
+        let model = Self.makeModel()
+        container = NSPersistentContainer(name: "BallogModel", managedObjectModel: model)
+
+        if inMemory {
+            let description = NSPersistentStoreDescription()
+            description.type = NSInMemoryStoreType
+            container.persistentStoreDescriptions = [description]
+        }
+
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Unresolved error \(error)")
+            }
+        }
+    }
+
+    static func makeModel() -> NSManagedObjectModel {
+        let model = NSManagedObjectModel()
+
+        let entity = NSEntityDescription()
+        entity.name = "AccountEntity"
+        entity.managedObjectClassName = String(describing: AccountEntity.self)
+
+        let username = NSAttributeDescription()
+        username.name = "username"
+        username.attributeType = .stringAttributeType
+        username.isOptional = false
+
+        let password = NSAttributeDescription()
+        password.name = "password"
+        password.attributeType = .stringAttributeType
+        password.isOptional = false
+
+        let email = NSAttributeDescription()
+        email.name = "email"
+        email.attributeType = .stringAttributeType
+        email.isOptional = false
+
+        entity.properties = [username, password, email]
+        model.entities = [entity]
+
+        return model
+    }
+
+    func save() {
+        let context = container.viewContext
+        if context.hasChanges {
+            try? context.save()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 BallogApp is a small SwiftUI experiment structured with the MVVM (Model–View–ViewModel) pattern.
 
+The app stores user sign-up information using **Core Data** via a lightweight stack defined in `Utilities/CoreDataStack.swift`.
+
 ## Design Philosophy
 
 The UI follows the core principles described in Apple’s Human Interface Guidelines:
@@ -14,6 +16,7 @@ The UI follows the core principles described in Apple’s Human Interface Guidel
 
 - `Ballog/App` - Application entry point
 - `Ballog/Models` - Model types
+- `Ballog/Utilities` - Helpers including the Core Data stack
 - `Ballog/ViewModels` - ViewModel logic (currently empty)
 - `Ballog/Views` - SwiftUI views
 - `Ballog/Assets.xcassets` - Assets used by the app


### PR DESCRIPTION
## Summary
- introduce `CoreDataStack` and `AccountEntity` for persistent user accounts
- persist new accounts in `SignUpView`
- read accounts from Core Data in `LoginView`
- integrate stack with `BallogApp`
- document new Core Data usage in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687366e84ec0832486fd303c507b60b2