### PR TITLE
Improve team screen and add global top bar

### DIFF
--- a/Ballog/Views/BallogTopBar.swift
+++ b/Ballog/Views/BallogTopBar.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct BallogTopBar: View {
+    private var todayString: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy M월 d일 EEEE"
+        return formatter.string(from: Date())
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("볼로그")
+                    .font(.title2.bold())
+                Text(todayString)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.leading)
+
+            Spacer()
+
+            NavigationLink(destination: ProfileView()) {
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .frame(width: 28, height: 28)
+            }
+            NavigationLink(destination: NotificationView()) {
+                Image(systemName: "bell")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+            }
+            NavigationLink(destination: SettingsView()) {
+                Image(systemName: "gearshape")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+            }
+        }
+        .padding(.vertical, 8)
+        .background(Color.pageBackground)
+    }
+}
+
+struct BallogTopBarModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        ZStack(alignment: .top) {
+            content
+                .padding(.top, 60)
+            BallogTopBar()
+        }
+        .ignoresSafeArea(edges: .top)
+    }
+}
+
+extension View {
+    func ballogTopBar() -> some View {
+        modifier(BallogTopBarModifier())
+    }
+}
+
+#Preview {
+    NavigationStack {
+        Text("Preview")
+            .ballogTopBar()
+    }
+}

--- a/Ballog/Views/FeedView.swift
+++ b/Ballog/Views/FeedView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 /// 피드 탭은 현재 준비 중이다.
 struct FeedView: View {
     var body: some View {
-        Text("피드 준비 중")
+        NavigationStack {
+            Text("피드 준비 중")
+        }
+        .ballogTopBar()
     }
 }
 

--- a/Ballog/Views/MainHomeView.swift
+++ b/Ballog/Views/MainHomeView.swift
@@ -52,12 +52,6 @@ struct MainHomeView: View {
         return try? JSONDecoder().decode(ProfileCard.self, from: data)
     }
 
-    private var todayString: String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy M월 d일 EEEE"
-        return formatter.string(from: Date())
-    }
 
     private var competitionEvents: [TeamEvent] {
         eventStore.events.filter { $0.type == .match }.sorted { $0.date < $1.date }
@@ -90,9 +84,6 @@ struct MainHomeView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: Layout.spacing) {
-                Spacer(minLength: 60) // 위 여백
-
-                topBar
                 quoteSection
                 scheduleSection
                 thisWeekScheduleSection // 추가된 부분
@@ -107,39 +98,9 @@ struct MainHomeView: View {
             .ignoresSafeArea()
             .onAppear { quote = quotes.randomElement() ?? "" }
         }
+        .ballogTopBar()
     }
 
-    private var topBar: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("볼로그")
-                    .font(.title2.bold())
-                Text(todayString)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-            .padding(.leading)
-
-            Spacer()
-
-            NavigationLink(destination: ProfileView()) {
-                Image(systemName: "person.circle.fill")
-                    .resizable()
-                    .frame(width: 28, height: 28)
-            }
-            NavigationLink(destination: NotificationView()) {
-                Image(systemName: "bell")
-                    .resizable()
-                    .frame(width: 24, height: 24)
-            }
-            NavigationLink(destination: SettingsView()) {
-                Image(systemName: "gearshape")
-                    .resizable()
-                    .frame(width: 24, height: 24)
-            }
-        }
-        .padding(.vertical, 8)
-    }
 
     private var quoteSection: some View {
         VStack(spacing: 8) {

--- a/Ballog/Views/NotificationView.swift
+++ b/Ballog/Views/NotificationView.swift
@@ -13,7 +13,6 @@ struct NotificationView: View {
 
     var body: some View {
         NavigationStack {
-            Spacer(minLength: 100) // 위 여백
             List(posts, id: \.self) { post in
                 Text(post)
             }
@@ -24,6 +23,7 @@ struct NotificationView: View {
         }
         .background(Color.pageBackground)
         .ignoresSafeArea()
+        .ballogTopBar()
     }
 }
 

--- a/Ballog/Views/PersonalTrainingView.swift
+++ b/Ballog/Views/PersonalTrainingView.swift
@@ -101,6 +101,7 @@ struct PersonalTrainingView: View {
         }
         .background(Color.pageBackground)
         .ignoresSafeArea()
+        .ballogTopBar()
     }
 }
 

--- a/Ballog/Views/SettingsView.swift
+++ b/Ballog/Views/SettingsView.swift
@@ -19,7 +19,6 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationStack {
-            Spacer(minLength: 100) // 위 여백
             List {
                 Section(header: Text("계정")) {
                     NavigationLink("프로필") {
@@ -47,6 +46,7 @@ struct SettingsView: View {
         }
         .background(Color.pageBackground)
         .ignoresSafeArea()
+        .ballogTopBar()
     }
 }
 

--- a/Ballog/Views/TeamCreationView.swift
+++ b/Ballog/Views/TeamCreationView.swift
@@ -6,6 +6,8 @@ struct TeamCreationView: View {
     @State private var step: Step = .name
 
     @EnvironmentObject private var teamStore: TeamStore
+    @EnvironmentObject private var eventStore: TeamEventStore
+    @EnvironmentObject private var logStore: TeamTrainingLogStore
     @AppStorage("currentTeamID") private var currentTeamID: String = ""
     @AppStorage("hasTeam") private var hasTeam: Bool = true
 
@@ -77,6 +79,8 @@ struct TeamCreationView: View {
                 teamStore.add(team)
                 currentTeamID = team.id.uuidString
                 hasTeam = true
+                eventStore.events.removeAll()
+                logStore.logs.removeAll()
             }
         }
     }

--- a/Ballog/Views/TeamManagementView.swift
+++ b/Ballog/Views/TeamManagementView.swift
@@ -129,12 +129,6 @@ struct TeamManagementView: View {
             if let next = tuesdayDates.first {
                 trainingWeather = WeatherService.weather(for: next)
             }
-            if eventStore.events.isEmpty {
-                let events = tuesdayDates.map { date in
-                    TeamEvent(date: date, title: "정기 훈련", place: "누누 풋살장", type: .training)
-                }
-                eventStore.events.append(contentsOf: events)
-            }
         }
         .sheet(item: $selectedLog) { data in
             TrainingLogDetailView(day: data.day, log: data.log)

--- a/Ballog/Views/TeamPageView.swift
+++ b/Ballog/Views/TeamPageView.swift
@@ -17,25 +17,25 @@ struct TeamPageView: View {
     }
 
     var body: some View {
-        if let team = currentTeam {
-            VStack {
-                Picker("TeamTab", selection: $selection) {
-                    ForEach(TeamTab.allCases, id: \.self) { Text($0.rawValue).tag($0) }
-                }
-                .pickerStyle(.segmented)
-                .padding()
+        NavigationStack {
+            if let team = currentTeam {
+                VStack {
+                    Picker("TeamTab", selection: $selection) {
+                        ForEach(TeamTab.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding()
 
-                switch selection {
-                case .manage:
-                    TeamManagementView(team: team)
-                case .ranking:
-                    TeamRankingView()
-                case .match:
-                    MatchManagementView()
+                    switch selection {
+                    case .manage:
+                        TeamManagementView(team: team)
+                    case .ranking:
+                        TeamRankingView()
+                    case .match:
+                        MatchManagementView()
+                    }
                 }
-            }
-        } else {
-            NavigationStack {
+            } else {
                 VStack(spacing: 16) {
                     if !hasTeam {
                         Text("팀에 가입해보세요")
@@ -53,6 +53,7 @@ struct TeamPageView: View {
                 }
             }
         }
+        .ballogTopBar()
     }
 }
 


### PR DESCRIPTION
## Summary
- add reusable BallogTopBar with modifier
- apply the top bar on main pages
- clear team data when creating a new team
- remove sample events from team management

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68736b4b998483248cfdc063acb96a50