### PR TITLE
Fix log store access when creating a team

### DIFF
--- a/Ballog/Models/TeamTrainingLogStore.swift
+++ b/Ballog/Models/TeamTrainingLogStore.swift
@@ -8,4 +8,10 @@ final class TeamTrainingLogStore: ObservableObject {
         let day = calendar.startOfDay(for: log.date)
         logs[day, default: []].append(log)
     }
+
+    /// Remove all stored logs. Useful when a new team is created and the
+    /// previous team's logs should be cleared.
+    func removeAll() {
+        logs.removeAll()
+    }
 }

--- a/Ballog/Views/TeamCreationView.swift
+++ b/Ballog/Views/TeamCreationView.swift
@@ -80,7 +80,7 @@ struct TeamCreationView: View {
                 currentTeamID = team.id.uuidString
                 hasTeam = true
                 eventStore.events.removeAll()
-                logStore.logs.removeAll()
+                logStore.removeAll()
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a `removeAll()` method to `TeamTrainingLogStore`
- clear logs using the new method when a team is created

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68736e3352048324b218f1c276862bec