### PR TITLE
Fix logout flow to show login

### DIFF
--- a/Ballog/App/BallogApp.swift
+++ b/Ballog/App/BallogApp.swift
@@ -52,6 +52,9 @@ struct BallogApp: App {
                         .onChange(of: storedCard) { newValue in
                             if newValue.isEmpty { showProfileCreator = true }
                         }
+                        .onChange(of: isLoggedIn) { newValue in
+                            if !newValue { showProfileCreator = false }
+                        }
                 } else {
                     LoginView()
                         .environmentObject(eventStore)

--- a/Ballog/Views/SettingsView.swift
+++ b/Ballog/Views/SettingsView.swift
@@ -15,6 +15,9 @@ struct SettingsView: View {
     @AppStorage("profileCard") private var storedCard: String = ""
     @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
     @AppStorage("currentTeamID") private var currentTeamID: String = ""
+    @AppStorage("autoLogin") private var autoLogin: Bool = false
+    @AppStorage("savedUsername") private var savedUsername: String = ""
+    @AppStorage("savedPassword") private var savedPassword: String = ""
     @State private var showLogoutAlert = false
 
     var body: some View {
@@ -39,6 +42,9 @@ struct SettingsView: View {
                     storedCard = ""
                     isLoggedIn = false
                     currentTeamID = ""
+                    autoLogin = false
+                    savedUsername = ""
+                    savedPassword = ""
                 }
                 Button("아니오", role: .cancel) { }
             }


### PR DESCRIPTION
## Summary
- ensure profile card sheet dismisses on logout
- clear auto login state and stored credentials when logging out

## Testing
- `swift --version`
- `swift package describe` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737064d8208324a67352bd41ad380e