### PR TITLE
Implement simple admin management screen

### DIFF
--- a/Ballog/App/BallogApp.swift
+++ b/Ballog/App/BallogApp.swift
@@ -33,6 +33,7 @@ struct BallogApp: App {
     @AppStorage("autoLogin") private var autoLogin: Bool = false
     @AppStorage("savedUsername") private var savedUsername: String = ""
     @AppStorage("savedPassword") private var savedPassword: String = ""
+    @AppStorage("isAdminUser") private var isAdminUser: Bool = false
     @State private var showProfileCreator = false
     private let persistenceController = CoreDataStack.shared
 
@@ -66,6 +67,7 @@ struct BallogApp: App {
                     req.predicate = NSPredicate(format: "username == %@", savedUsername)
                     if let account = try? persistenceController.container.viewContext.fetch(req).first,
                        account.password == savedPassword {
+                        isAdminUser = account.isAdmin
                         isLoggedIn = true
                     }
                 }

--- a/Ballog/Models/AccountEntity.swift
+++ b/Ballog/Models/AccountEntity.swift
@@ -6,6 +6,7 @@ final class AccountEntity: NSManagedObject {
     @NSManaged var username: String
     @NSManaged var password: String
     @NSManaged var email: String
+    @NSManaged var isAdmin: Bool
 }
 
 extension AccountEntity {
@@ -13,3 +14,5 @@ extension AccountEntity {
         NSFetchRequest<AccountEntity>(entityName: "AccountEntity")
     }
 }
+
+extension AccountEntity: Identifiable {}

--- a/Ballog/Utilities/CoreDataStack.swift
+++ b/Ballog/Utilities/CoreDataStack.swift
@@ -45,7 +45,13 @@ final class CoreDataStack {
         email.attributeType = .stringAttributeType
         email.isOptional = false
 
-        entity.properties = [username, password, email]
+        let isAdmin = NSAttributeDescription()
+        isAdmin.name = "isAdmin"
+        isAdmin.attributeType = .booleanAttributeType
+        isAdmin.isOptional = false
+        isAdmin.defaultValue = false
+
+        entity.properties = [username, password, email, isAdmin]
         model.entities = [entity]
 
         return model

--- a/Ballog/Views/AdminView.swift
+++ b/Ballog/Views/AdminView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import CoreData
+
+private enum Layout {
+    static let padding = DesignConstants.horizontalPadding
+}
+
+struct AdminView: View {
+    @FetchRequest(entity: AccountEntity.entity(), sortDescriptors: [])
+    private var accounts: FetchedResults<AccountEntity>
+    @Environment(\.managedObjectContext) private var context
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(accounts) { account in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(account.username)
+                                .font(.headline)
+                            Text(account.email)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        Toggle("관리자", isOn: Binding(get: { account.isAdmin }, set: { newVal in
+                            account.isAdmin = newVal
+                            try? context.save()
+                        }))
+                        .labelsHidden()
+                    }
+                }
+                .onDelete(perform: delete)
+            }
+            .listStyle(.insetGrouped)
+            .padding(.horizontal, Layout.padding)
+            .navigationTitle("사용자 관리")
+            .toolbar { EditButton() }
+            .scrollContentBackground(.hidden)
+        }
+        .background(Color.pageBackground)
+        .ignoresSafeArea()
+        .ballogTopBar()
+    }
+
+    private func delete(at offsets: IndexSet) {
+        for index in offsets {
+            context.delete(accounts[index])
+        }
+        try? context.save()
+    }
+}
+
+#Preview {
+    AdminView()
+        .environment(\.managedObjectContext, CoreDataStack.shared.container.viewContext)
+}

--- a/Ballog/Views/ContentView.swift
+++ b/Ballog/Views/ContentView.swift
@@ -7,6 +7,8 @@
 import SwiftUI
 
 struct ContentView: View {
+    @AppStorage("isAdminUser") private var isAdminUser: Bool = false
+
     var body: some View {
         TabView {
             MainHomeView()
@@ -38,6 +40,14 @@ struct ContentView: View {
                     Image(systemName: "gearshape")
                     Text("설정")
                 }
+
+            if isAdminUser {
+                AdminView()
+                    .tabItem {
+                        Image(systemName: "lock.shield")
+                        Text("관리자")
+                    }
+            }
         }
         .background(Color.pageBackground)
         .ignoresSafeArea()

--- a/Ballog/Views/LoginView.swift
+++ b/Ballog/Views/LoginView.swift
@@ -8,6 +8,7 @@ struct LoginView: View {
     @AppStorage("savedPassword") private var savedPassword: String = ""
     @AppStorage("rememberID") private var rememberID: Bool = false
     @AppStorage("autoLogin") private var autoLogin: Bool = false
+    @AppStorage("isAdminUser") private var isAdminUser: Bool = false
     @Environment(\.managedObjectContext) private var context
 
     @State private var username: String = ""
@@ -52,6 +53,7 @@ struct LoginView: View {
             let req = AccountEntity.fetchRequest()
             req.predicate = NSPredicate(format: "username == %@", username)
             if let account = try? context.fetch(req).first, account.password == password {
+                isAdminUser = account.isAdmin
                 isLoggedIn = true
             }
         }
@@ -81,6 +83,7 @@ struct LoginView: View {
 
         if rememberID { savedUsername = username } else { savedUsername = "" }
         if autoLogin { savedPassword = password } else { savedPassword = "" }
+        isAdminUser = account.isAdmin
         isLoggedIn = true
     }
 }

--- a/Ballog/Views/SettingsView.swift
+++ b/Ballog/Views/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @AppStorage("autoLogin") private var autoLogin: Bool = false
     @AppStorage("savedUsername") private var savedUsername: String = ""
     @AppStorage("savedPassword") private var savedPassword: String = ""
+    @AppStorage("isAdminUser") private var isAdminUser: Bool = false
     @State private var showLogoutAlert = false
 
     var body: some View {
@@ -45,6 +46,7 @@ struct SettingsView: View {
                     autoLogin = false
                     savedUsername = ""
                     savedPassword = ""
+                    isAdminUser = false
                 }
                 Button("아니오", role: .cancel) { }
             }

--- a/Ballog/Views/SignUpView.swift
+++ b/Ballog/Views/SignUpView.swift
@@ -40,6 +40,7 @@ struct SignUpView: View {
         newAccount.username = username
         newAccount.password = password
         newAccount.email = email
+        newAccount.isAdmin = false
 
         try? context.save()
         dismiss()


### PR DESCRIPTION
## Summary
- include `isAdmin` field in account model and persistence stack
- add `AdminView` listing user accounts with admin toggles and delete
- show Admin tab only for admin accounts
- store admin state on login/logout and during auto login

## Testing
- `xcodebuild -list -project Ballog.xcodeproj | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687373bfba188324a87dd558b25d5529