### PR TITLE
Fix top bar overlapping with iOS status bar

### DIFF
--- a/Ballog/Views/BallogTopBar.swift
+++ b/Ballog/Views/BallogTopBar.swift
@@ -49,7 +49,6 @@ struct BallogTopBarModifier: ViewModifier {
                 .padding(.top, 100)
             BallogTopBar()
         }
-        .ignoresSafeArea(edges: .top)
     }
 }
 


### PR DESCRIPTION
## Summary
- keep BallogTopBar inside the safe area so it no longer overlaps the iOS status bar

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68737964676c8324a0d95df16a4a12ba