### PR TITLE
Implement tactic management

### DIFF
--- a/Ballog/App/BallogApp.swift
+++ b/Ballog/App/BallogApp.swift
@@ -28,6 +28,7 @@ struct BallogApp: App {
     @StateObject private var logStore = TeamTrainingLogStore()
     @StateObject private var teamStore = TeamStore()
     @StateObject private var eventStore = TeamEventStore()
+    @StateObject private var tacticStore = TeamTacticStore()
     @AppStorage("profileCard") private var storedCard: String = ""
     @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
     @AppStorage("autoLogin") private var autoLogin: Bool = false
@@ -46,6 +47,7 @@ struct BallogApp: App {
                         .environmentObject(logStore)
                         .environmentObject(teamStore)
                         .environmentObject(eventStore)
+                        .environmentObject(tacticStore)
                         .sheet(isPresented: $showProfileCreator) {
                             ProfileCardCreationView()
                         }

--- a/Ballog/Models/TeamTactic.swift
+++ b/Ballog/Models/TeamTactic.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct TeamTactic: Identifiable, Codable {
+    let id: UUID
+    var name: String
+    var formation: String
+    var notes: String
+    var imageData: Data?
+    var createdAt: Date
+
+    init(id: UUID = UUID(), name: String, formation: String, notes: String = "", imageData: Data? = nil, createdAt: Date = Date()) {
+        self.id = id
+        self.name = name
+        self.formation = formation
+        self.notes = notes
+        self.imageData = imageData
+        self.createdAt = createdAt
+    }
+}

--- a/Ballog/Models/TeamTacticStore.swift
+++ b/Ballog/Models/TeamTacticStore.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class TeamTacticStore: ObservableObject {
+    @Published var tactics: [TeamTactic] = []
+
+    func add(_ tactic: TeamTactic) { tactics.append(tactic) }
+    func remove(at offsets: IndexSet) { tactics.remove(atOffsets: offsets) }
+    func update(_ tactic: TeamTactic) {
+        if let index = tactics.firstIndex(where: { $0.id == tactic.id }) {
+            tactics[index] = tactic
+        }
+    }
+}

--- a/Ballog/Views/ContentView.swift
+++ b/Ballog/Views/ContentView.swift
@@ -58,4 +58,5 @@ struct ContentView: View {
     ContentView()
         .environmentObject(AttendanceStore())
         .environmentObject(TeamTrainingLogStore())
+        .environmentObject(TeamTacticStore())
 }

--- a/Ballog/Views/TeamPageView.swift
+++ b/Ballog/Views/TeamPageView.swift
@@ -4,6 +4,7 @@ private enum TeamTab: String, CaseIterable {
     case manage = "팀 관리"
     case ranking = "팀 랭킹"
     case match = "매치 관리"
+    case tactics = "전술"
 }
 
 struct TeamPageView: View {
@@ -33,6 +34,8 @@ struct TeamPageView: View {
                         TeamRankingView()
                     case .match:
                         MatchManagementView()
+                    case .tactics:
+                        TeamTacticsView()
                     }
                 }
             } else {
@@ -61,5 +64,6 @@ struct TeamPageView: View {
     TeamPageView()
         .environmentObject(AttendanceStore())
         .environmentObject(TeamTrainingLogStore())
+        .environmentObject(TeamTacticStore())
 }
 

--- a/Ballog/Views/TeamTacticsView.swift
+++ b/Ballog/Views/TeamTacticsView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import PhotosUI
+
+struct TeamTacticsView: View {
+    @EnvironmentObject private var tacticStore: TeamTacticStore
+    @EnvironmentObject private var logStore: TeamTrainingLogStore
+    @State private var showingForm = false
+    @State private var selectedTactic: TeamTactic?
+
+    private func count(for tactic: TeamTactic) -> Int {
+        logStore.logs.values
+            .flatMap { $0 }
+            .filter { $0.tactic == tactic.name }
+            .count
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(tacticStore.tactics) { tactic in
+                    NavigationLink(destination: TeamTacticDetailView(tactic: tactic, count: count(for: tactic))) {
+                        HStack {
+                            Text(tactic.name)
+                            Spacer()
+                            Text("\(count(for: tactic))회")
+                                .foregroundColor(.secondary)
+                                .font(.caption)
+                        }
+                    }
+                }
+                .onDelete { tacticStore.remove(at: $0) }
+            }
+            .navigationTitle("팀 전술")
+            .toolbar {
+                Button(action: { showingForm = true }) { Image(systemName: "plus") }
+            }
+            .sheet(isPresented: $showingForm) {
+                TeamTacticFormView { tactic in
+                    tacticStore.add(tactic)
+                }
+            }
+        }
+    }
+}
+
+struct TeamTacticDetailView: View {
+    var tactic: TeamTactic
+    var count: Int
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(tactic.name)
+                    .font(.title)
+                Text("포메이션: \(tactic.formation)")
+                if let data = tactic.imageData, let uiImage = UIImage(data: data) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                }
+                Text(tactic.notes)
+                Text("훈련 횟수: \(count)")
+                Spacer()
+            }
+            .padding()
+        }
+        .navigationTitle(tactic.name)
+    }
+}
+
+struct TeamTacticFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var formation = ""
+    @State private var notes = ""
+    @State private var pickerItem: PhotosPickerItem?
+    @State private var imageData: Data?
+
+    var onSave: (TeamTactic) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("전술 이름", text: $name)
+                TextField("포메이션", text: $formation)
+                Section(header: Text("플레이 패턴")) {
+                    TextEditor(text: $notes)
+                        .frame(height: 100)
+                }
+                PhotosPicker(selection: $pickerItem, matching: .images) {
+                    Text("이미지 선택")
+                }
+                if let data = imageData, let ui = UIImage(data: data) {
+                    Image(uiImage: ui)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 200)
+                }
+            }
+            .navigationTitle("전술 추가")
+            .toolbar {
+                Button("저장") {
+                    let tactic = TeamTactic(name: name, formation: formation, notes: notes, imageData: imageData)
+                    onSave(tactic)
+                    dismiss()
+                }
+            }
+            .onChange(of: pickerItem) { newItem in
+                if let newItem {
+                    Task {
+                        imageData = try? await newItem.loadTransferable(type: Data.self)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    TeamTacticsView()
+        .environmentObject(TeamTacticStore())
+        .environmentObject(TeamTrainingLogStore())
+}


### PR DESCRIPTION
## Summary
- add TeamTactic model and store
- create UI for managing team tactics and recording formations
- show tactic tab on team page
- pass tactic store through environment objects

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737d562e988324a825de7eba267ec4