### PR TITLE
Improve team workflow

### DIFF
--- a/Ballog/Models/Team.swift
+++ b/Ballog/Models/Team.swift
@@ -6,12 +6,30 @@ struct Team: Identifiable, Codable {
     var sport: String
     var gender: String
     var type: String
-    
-    init(id: UUID = UUID(), name: String, sport: String = "풋살", gender: String = "혼성", type: String = "club") {
+    var region: String
+    let code: String
+    var trainingTime: String
+    var members: [TeamCharacter]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        sport: String = "풋살",
+        gender: String = "혼성",
+        type: String = "club",
+        region: String = "",
+        code: String = String(UUID().uuidString.prefix(8)),
+        trainingTime: String = "매주 화요일 19:00",
+        members: [TeamCharacter] = []
+    ) {
         self.id = id
         self.name = name
         self.sport = sport
         self.gender = gender
         self.type = type
+        self.region = region
+        self.code = code
+        self.trainingTime = trainingTime
+        self.members = members
     }
 }

--- a/Ballog/Models/TeamStore.swift
+++ b/Ballog/Models/TeamStore.swift
@@ -10,4 +10,9 @@ final class TeamStore: ObservableObject {
     func team(id: UUID) -> Team? {
         teams.first { $0.id == id }
     }
+
+    func addMember(_ member: TeamCharacter, to id: UUID) {
+        guard let index = teams.firstIndex(where: { $0.id == id }) else { return }
+        teams[index].members.append(member)
+    }
 }

--- a/Ballog/Views/TeamJoinView.swift
+++ b/Ballog/Views/TeamJoinView.swift
@@ -3,14 +3,47 @@ import SwiftUI
 struct TeamJoinView: View {
     @EnvironmentObject private var teamStore: TeamStore
     @AppStorage("currentTeamID") private var currentTeamID: String = ""
-    
+    @AppStorage("profileCard") private var storedCard: String = ""
+    @Environment(\.dismiss) private var dismiss
+    @State private var code: String = ""
+
+    private var userCard: ProfileCard? {
+        guard let data = storedCard.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ProfileCard.self, from: data)
+    }
+
     var body: some View {
-        List(teamStore.teams) { team in
-            Button(team.name) {
-                currentTeamID = team.id.uuidString
+        VStack {
+            TextField("팀 코드", text: $code)
+                .textFieldStyle(.roundedBorder)
+                .padding()
+            List(teamStore.teams) { team in
+                Button {
+                    join(team)
+                } label: {
+                    VStack(alignment: .leading) {
+                        Text(team.name)
+                            .font(.headline)
+                        Text(team.region)
+                        Text(team.trainingTime)
+                            .font(.caption)
+                    }
+                }
             }
         }
         .navigationTitle("추천 팀")
+    }
+
+    private func join(_ team: Team) {
+        guard code == team.code else { return }
+        let member = TeamCharacter(
+            name: userCard?.nickname ?? "나",
+            imageName: userCard?.iconName ?? "soccer-player",
+            isOnline: false
+        )
+        teamStore.addMember(member, to: team.id)
+        currentTeamID = team.id.uuidString
+        dismiss()
     }
 }
 

--- a/Ballog/Views/TeamManagementView.swift
+++ b/Ballog/Views/TeamManagementView.swift
@@ -67,21 +67,9 @@ struct TeamManagementView: View {
         return f
     }
     
-    @AppStorage("profileCard") private var storedCard: String = ""
-    
-    private var userName: String {
-        guard let data = storedCard.data(using: .utf8),
-              let card = try? JSONDecoder().decode(ProfileCard.self, from: data) else { return "사용자" }
-        return card.nickname
-    }
     
     private var teamMembers: [TeamCharacter] {
-        [
-            TeamCharacter(name: "혜진", imageName: "football-player-2", isOnline: true),
-            TeamCharacter(name: "규원", imageName: "football-player-3", isOnline: false, pose: .victory),
-            TeamCharacter(name: "진주", imageName: "goalkeeper", isOnline: true),
-            TeamCharacter(name: userName, imageName: "soccer-player", isOnline: false)
-        ]
+        team.members
     }
     
     private var sortedLogs: [(Date, TeamTrainingLog)] {
@@ -103,7 +91,6 @@ struct TeamManagementView: View {
             ScrollView {
                 VStack(spacing: Layout.spacing) {
                     TeamHeaderView(teamName: team.name)
-                    TeamQuoteView()
                     TeamCharacterBoardView(members: teamMembers, backgroundImage: backgroundImage) { member in
                         selectedMember = member
                     }
@@ -159,19 +146,6 @@ struct TeamManagementView: View {
         }
     }
     
-    private struct TeamQuoteView: View {
-        var body: some View {
-            HStack {
-                Image(systemName: "quote.bubble")
-                    .foregroundColor(.gray)
-                Text("“오늘도 파이팅!” - 잔디요정")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                Spacer()
-            }
-            .padding(.horizontal, Layout.padding)
-        }
-    }
     
     private struct CalendarSection: View {
         @Binding var selectedDate: Date?

--- a/Ballog/Views/TeamPageView.swift
+++ b/Ballog/Views/TeamPageView.swift
@@ -49,7 +49,15 @@ struct TeamPageView: View {
                         Text("추천 팀")
                             .font(.headline)
                         ForEach(teamStore.teams) { team in
-                            Text(team.name)
+                            NavigationLink(destination: TeamPreviewView(team: team)) {
+                                VStack(alignment: .leading) {
+                                    Text(team.name)
+                                        .fontWeight(.bold)
+                                    Text(team.region)
+                                    Text(team.trainingTime)
+                                        .font(.caption)
+                                }
+                            }
                         }
                     }
                     Spacer()

--- a/Ballog/Views/TeamPreviewView.swift
+++ b/Ballog/Views/TeamPreviewView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct TeamPreviewView: View {
+    let team: Team
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(team.name)
+                .font(.largeTitle)
+                .padding(.top)
+            TeamCharacterBoardView(members: team.members)
+            Spacer()
+        }
+        .navigationTitle("팀 미리보기")
+        .padding()
+    }
+}
+
+#Preview {
+    TeamPreviewView(team: Team(name: "샘플", region: "서울", members: [TeamCharacter(name: "A", imageName: "soccer-player", isOnline: true)]))
+}


### PR DESCRIPTION
## Summary
- track team members and region with new fields in `Team`
- update `TeamStore` for member management
- ask for activity region during team creation
- add team code check and info when joining
- clean up team management view and enable member preview
- show limited info for suggested teams
- add simple `TeamPreviewView` for public team view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6873836523e48324a6ff1896a88eac0f