### PR TITLE
Fix Team Codable error

### DIFF
--- a/Ballog/Views/TeamCharacterBoardView.swift
+++ b/Ballog/Views/TeamCharacterBoardView.swift
@@ -4,8 +4,8 @@ private enum Layout {
     static let padding = DesignConstants.horizontalPadding
 }
 
-struct TeamCharacter: Identifiable {
-    enum Pose: CaseIterable {
+struct TeamCharacter: Identifiable, Codable {
+    enum Pose: String, CaseIterable, Codable {
         case wave
         case victory
 


### PR DESCRIPTION
## Summary
- mark `TeamCharacter` and `TeamCharacter.Pose` as `Codable`

## Testing
- `swiftc Ballog/Models/Team.swift Ballog/Views/TeamCharacterBoardView.swift -parse-as-library -module-name Ballog -o /tmp/ballog.o` *(fails: no such module 'SwiftUI')*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68738555a2ec83249ce44c6a746f4833