### PR TITLE
Fix PersonalTrainingLogEntity attribute type

### DIFF
--- a/Ballog/Ballog.xcdatamodeld/Ballog.xcdatamodel/contents
+++ b/Ballog/Ballog.xcdatamodeld/Ballog.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="PersonalTrainingLogEntity" representedClassName="PersonalTrainingLogEntity" syncable="YES" codeGenerationType="class">
         <attribute name="achievements" optional="YES" attributeType="Transformable"/>
         <attribute name="categories" optional="YES" attributeType="Transformable"/>
-        <attribute name="coachingNotes" optional="YES" attributeType="Transformable"/>
+        <attribute name="coachingNotes" optional="YES" attributeType="String"/>
         <attribute name="condition" optional="YES" attributeType="String"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="duration" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>


### PR DESCRIPTION
## Summary
- ensure `coachingNotes` attribute is typed as `String` in the data model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876813a413883248c36b38e94cf436f