### PR TITLE
Fix missing FirebaseFirestoreSwift module

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,8 @@ platform :ios, '15.0'
 target 'Ballog' do
   use_frameworks!
   pod 'Firebase/Firestore'
+  # Needed for Codable support when using Firestore with Swift
+  pod 'FirebaseFirestoreSwift'
 end
 
 post_install do |installer|

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ BallogApp is a small SwiftUI experiment structured with the MVVM (Model–View�
 
 The app now stores user sign-up information using **Firebase Firestore** via helpers in `Utilities/FirestoreAccountService.swift`.
 
+## Setup
+
+Dependencies are managed with CocoaPods. Run `pod install` before opening the
+workspace. The app requires the `FirebaseFirestoreSwift` pod for Codable support
+when working with Firestore.
+
 ## Design Philosophy
 
 The UI follows the core principles described in Apple’s Human Interface Guidelines:


### PR DESCRIPTION
## Summary
- add `FirebaseFirestoreSwift` to CocoaPods dependencies
- update README with setup notes

## Testing
- `pod install --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d0d1e26883249660fe40c58ab1ed